### PR TITLE
chore: Add UNLICENSE, bump deps, remove unused config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,6 @@ Generated tests use `eval` with `*ns*` binding for namespace isolation.
 ## Test Configuration
 
 - `tests.edn` — Kaocha config focusing on `:rct` tests, skipping `:unit` and `:clr-only`
-- `tests_with_plugins.edn` — same with profiling and cloverage plugins
 - `test/rct_clr/rc_test.clj` — JVM test runner that scans `src/`, `examples/`, and `examples_jvm/` for RCT blocks
 - `gen.cljc` has inline `^:rct/test` blocks after each function — `bb rct` picks these up automatically
 - `gen_test.clj` — integration tests for writer functions, file discovery, and golden file snapshot matching

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rct-clr
 
-Generates CLR-compatible test files from [Rich Comment Tests](https://github.com/parth-io/rich-comment-tests) (`^:rct/test`) blocks.
+Generates CLR-compatible test files from [Rich Comment Tests](https://github.com/robertluo/rich-comment-tests) (`^:rct/test`) blocks.
 
 ## Why run RCT tests on the CLR?
 

--- a/UNLICENSE
+++ b/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/bb.edn
+++ b/bb.edn
@@ -21,6 +21,9 @@
          {:doc  "Run all JVM tests"
           :task (do (run 'gen-clr-rct)
                     (clojure (apply str "-M:dev:test " (interpose " " *command-line-args*))))}
+         outdated
+         {:doc "Show outdated dependencies"
+          :task (clojure "-M:outdated")}
          clr-test
          {:doc  "Run all CLR tests"
           :task (do (run 'gen-clr-rct)

--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,20 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
         io.github.robertluo/rich-comment-tests
         {:git/url "https://github.com/robertluo/rich-comment-tests"
          :git/sha "6765d3b73a9602aa38b1ad63af889c8c7b47c1d0"}
         org.clojure/tools.cli {:mvn/version "1.4.256"}}
  :aliases {:dev  {:extra-paths ["dev" "test" "examples" "examples_clr" "examples_jvm"]
-                  :extra-deps  {cider/cider-nrepl {:mvn/version "0.56.0"}
+                  :extra-deps  {cider/cider-nrepl {:mvn/version "0.58.0"}
                                 lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
            :test {:extra-paths ["test" "examples" "examples_clr" "examples_jvm"]
                   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                                 lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}}
                   :main-opts   ["-m" "kaocha.runner"]}
-           :dbg {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.3-1"}
+           :dbg {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.4"}
                               com.github.flow-storm/flow-storm-dbg {:mvn/version "4.5.9"}}}
+           :outdated {:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+                      :main-opts ["-m" "antq.core"]}
            :cljfmt
-           {:deps {io.github.weavejester/cljfmt {:git/tag "0.15.3" :git/sha "3518f24"}}
+           {:deps {io.github.weavejester/cljfmt {:git/tag "0.16.3" :git/sha "f138389"}}
             :ns-default cljfmt.tool}}}

--- a/dotnet.clj
+++ b/dotnet.clj
@@ -6,9 +6,7 @@
 
   This namespace provides convenient functions to:
   - compile the prod namespaces to .net assemblies
-  - run the tests in the CLR
-  - pack and push NuGet Packages to a host repo"
-
+  - run the tests in the CLR"
   (:require [clojure.test :refer [run-all-tests]]
             [magic.flags :as mflags]))
 

--- a/project.edn
+++ b/project.edn
@@ -1,6 +1,6 @@
 {:name         "rct-clr"
  :version      "1.0.0"
- :source-paths ["src" "test" "examples" "examples_clr"]
+ :source-paths ["test" "examples" "examples_clr"]
  :dependencies [[:github flybot-sg/matcho "magic"
                  :sha "1edae156dda891b2f1698afc4972f5456f49d039"
                  :paths ["src"]]]}

--- a/tests_with_plugins.edn
+++ b/tests_with_plugins.edn
@@ -1,8 +1,0 @@
-#kaocha/v1
- {:kaocha.filter/skip-meta [:clr-only]
-  :tests [{:id :rct
-           :focus-meta [:rct]}
-          {:id :unit
-           :skip-meta [:rct]}]
-  :plugins [:kaocha.plugin/profiling
-            :kaocha.plugin/cloverage]}


### PR DESCRIPTION
- Add UNLICENSE (public domain)
- Bump clojure, cider-nrepl, cljfmt, flow-storm to latest
- Add `bb outdated` task
- Remove unused `tests_with_plugins.edn`
- Fix README RCT link
- Remove `src` from project.edn source-paths
- Remove stale NuGet docstring from dotnet.clj