### PR TITLE
fix: Compare a => expectation as data and bind the REPL vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: ghcr.io/flybot-sg/ci-clj-clr:2.1.0
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Job-level env: cannot expand $HOME; nostrand and tools.deps read GITLIBS
       # literally, so it must be an absolute path. This makes nostrand clone its
@@ -20,7 +20,7 @@ jobs:
       - name: Point nostrand git deps at the cached gitlibs dir
         run: echo "GITLIBS=$HOME/.gitlibs" >> "$GITHUB_ENV"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.m2/repository

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.6"}
         io.github.robertluo/rich-comment-tests
         {:git/url "https://github.com/robertluo/rich-comment-tests"
          :git/sha "6765d3b73a9602aa38b1ad63af889c8c7b47c1d0"}
@@ -9,17 +9,17 @@
            :clr  {:override-deps {healthsamurai/matcho {:git/url "https://github.com/flybot-sg/matcho"
                                                         :git/sha "31225e185d5bbc2f13529730865bf9563677e646"}}}
            :dev  {:extra-paths ["dev" "test" "examples" "examples_clr" "examples_jvm"]
-                  :extra-deps  {cider/cider-nrepl {:mvn/version "0.58.0"}
+                  :extra-deps  {cider/cider-nrepl {:mvn/version "0.62.2"}
                                 nrepl/nrepl {:mvn/version "1.7.0"}
                                 lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
            :test {:extra-paths ["test" "examples" "examples_clr" "examples_jvm"]
                   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                                 lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}}
                   :main-opts   ["-m" "kaocha.runner"]}
-           :dbg {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.4"}
-                              com.github.flow-storm/flow-storm-dbg {:mvn/version "4.5.9"}}}
+           :dbg {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.5-1"}
+                              com.github.flow-storm/flow-storm-dbg {:mvn/version "4.8.1"}}}
            :outdated {:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
                       :main-opts ["-m" "antq.core"]}
            :cljfmt
-           {:deps {io.github.weavejester/cljfmt {:git/tag "0.16.3" :git/sha "f138389"}}
+           {:deps {io.github.weavejester/cljfmt {:git/tag "0.16.5" :git/sha "609d570"}}
             :ns-default cljfmt.tool}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
                                                         :git/sha "31225e185d5bbc2f13529730865bf9563677e646"}}}
            :dev  {:extra-paths ["dev" "test" "examples" "examples_clr" "examples_jvm"]
                   :extra-deps  {cider/cider-nrepl {:mvn/version "0.58.0"}
+                                nrepl/nrepl {:mvn/version "1.7.0"}
                                 lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
            :test {:extra-paths ["test" "examples" "examples_clr" "examples_jvm"]
                   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}

--- a/examples/rct_clr/sample.cljc
+++ b/examples/rct_clr/sample.cljc
@@ -61,6 +61,25 @@
   ;=> (+ 2 2)
   )
 
+;; --- Chaining off *1 and *2 ---
+
+(defn stack-push [stack x]
+  (conj stack x))
+
+^:rct/test
+(comment
+  (stack-push [1 2] 3)
+  ;=> [1 2 3]
+
+  ;; *1 carries the previous result
+  (count *1)
+  ;=> 3
+
+  ;; *2 reaches one form further back
+  (peek *2)
+  ;=> 3
+  )
+
 ;; --- String operations and alias-qualified calls ---
 
 (defn greet [name]

--- a/examples/rct_clr/sample.cljc
+++ b/examples/rct_clr/sample.cljc
@@ -34,6 +34,33 @@
   ;=> 21
   )
 
+;; --- Seq-valued and symbol expectations ---
+
+(defn suits []
+  (list :h :c :s :d))
+
+(defn a-symbol []
+  'foo)
+
+^:rct/test
+(comment
+  ;; a keyword-headed list cannot be called, so it compares as data
+  (suits)
+  ;=> (:h :c :s :d)
+
+  ;; a number in head position, the value-type case
+  (map inc (range 3))
+  ;=> (1 2 3)
+
+  ;; a symbol compares as a symbol, it is not resolved
+  (a-symbol)
+  ;=> foo
+
+  ;; an expectation that does evaluate keeps its value
+  (count (suits))
+  ;=> (+ 2 2)
+  )
+
 ;; --- String operations and alias-qualified calls ---
 
 (defn greet [name]

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -259,36 +259,40 @@
 
 (defn datum->form
   "Convert an RCT datum to a Clojure form for the generated test.
-  A => expectation that is not self-evaluating goes through eval-expectation at
-  test time, so an earlier form's defs are in place by the time it evaluates."
+  Value-producing forms pass through bind-repl-vars! so a later form in the
+  same block can chain off *1. A => expectation that is not self-evaluating goes
+  through eval-expectation at test time, so an earlier form's defs are in place
+  by the time it evaluates."
   [{:keys [test-sexpr expectation-type] :as datum} ns-sym output-ns]
   (let [error->map-sym (symbol (str output-ns) "error->map")
         eval-sym (symbol (str output-ns) "eval-expectation")
-        expectation (read-expectation datum ns-sym)]
+        expectation (read-expectation datum ns-sym)
+        bound-sexpr (list (symbol (str output-ns) "bind-repl-vars!") test-sexpr)]
     (case expectation-type
-      ;; nil = side-effect form (def, require), emit raw
-      nil test-sexpr
+      ;; nil = side-effect form (def, require)
+      nil bound-sexpr
       => (list 'clojure.test/is
                (list '= (if (self-evaluating? expectation)
                           expectation
                           (list eval-sym (list 'quote expectation)))
-                     test-sexpr))
-      =>> (list 'matcho.core/assert expectation test-sexpr)
+                     bound-sexpr))
+      =>> (list 'matcho.core/assert expectation bound-sexpr)
       throws=>> (list 'try test-sexpr
                       (list 'clojure.test/is false "Expected exception")
                       (list 'catch 'System.Exception 'e
+                            (list 'set! '*e 'e)
                             (list 'matcho.core/assert
                                   expectation
                                   (list error->map-sym 'e)))))))
 
 ^:rct/test
 (comment
-  ;; nil expectation: side-effect, returns raw expression
+  ;; nil expectation: side-effect, wrapped so it feeds *1
   (datum->form {:test-sexpr '(def x 1)
                 :expectation-type nil}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(def x 1)
+  ;=> '(test-output-ns/bind-repl-vars! (def x 1))
 
   ;; => expectation: equality assertion
   (datum->form {:test-sexpr '(+ 1 2)
@@ -296,7 +300,7 @@
                 :expectation-type '=>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(clojure.test/is (= 3 (+ 1 2)))
+  ;=> '(clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))
 
   ;; => a non-self-evaluating expectation is handed to eval-expectation
   (datum->form {:test-sexpr '(order)
@@ -304,15 +308,15 @@
                 :expectation-type '=>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (order)))
+  ;=> '(clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))
 
-  ;; =>> expectation: matcho pattern
+  ;; =>> expectation: matcho pattern, kept as code
   (datum->form {:test-sexpr '(get-status)
                 :expectation-string "{:status 200}"
                 :expectation-type '=>>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(matcho.core/assert {:status 200} (get-status))
+  ;=> '(matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))
 
   ;; =>> with ellipsis elision
   (datum->form {:test-sexpr '(range 5)
@@ -320,9 +324,9 @@
                 :expectation-type '=>>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(matcho.core/assert [0 1] (range 5))
+  ;=> '(matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))
 
-  ;; throws=>>: full try/catch structure with qualified error->map
+  ;; throws=>>: try/catch, binds *e, qualified error->map
   (datum->form {:test-sexpr '(boom!)
                 :expectation-string "{:error/class Exception}"
                 :expectation-type 'throws=>>}
@@ -332,6 +336,7 @@
   '(try (boom!)
         (clojure.test/is false "Expected exception")
         (catch System.Exception e
+          (set! *e e)
           (matcho.core/assert {:error/class Exception}
                               (test-output-ns/error->map e))))
 
@@ -341,7 +346,7 @@
                 :expectation-type '=>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(clojure.test/is (= :clr (get-platform)))
+  ;=> '(clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))
 
   ;; => with namespace-qualified keyword in expectation
   (datum->form {:test-sexpr '(get-type)
@@ -349,7 +354,7 @@
                 :expectation-type '=>}
                'rct-clr.gen
                'test-output-ns)
-  ;=> '(clojure.test/is (= :rct-clr.gen/foo (get-type)))
+  ;=> '(clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))
   )
 
 (defn ns-sym->test-base
@@ -396,15 +401,18 @@
 
 (defn write-deftest
   "Write a deftest that calls block fns in order.
-  Binds *ns* to the source namespace so eval'd forms resolve there."
+  Binds *ns* to the source namespace so eval'd forms resolve there, and the
+  REPL vars so bind-repl-vars! has a thread-local to set!."
   [w ns-sym block-infos]
   (let [test-sym (str (ns-sym->test-base ns-sym) "-rct")
         calls (mapv #(str "(" (:fn-sym %) ")") block-infos)]
     (.write w (str "(deftest " test-sym "\n"))
     (if (empty? calls)
-      (.write w (str "  (binding [*ns* (the-ns '" ns-sym ")]))\n\n"))
+      (.write w (str "  (binding [*ns* (the-ns '" ns-sym ")\n"
+                     "            *1 nil, *2 nil, *3 nil, *e nil]))\n\n"))
       (do
-        (.write w (str "  (binding [*ns* (the-ns '" ns-sym ")]\n"))
+        (.write w (str "  (binding [*ns* (the-ns '" ns-sym ")\n"
+                       "            *1 nil, *2 nil, *3 nil, *e nil]\n"))
         (.write w (str "    " (string/join "\n    " calls) "))\n\n"))))))
 
 (def ^:private error->map-str
@@ -428,8 +436,17 @@
     (catch #?(:clj Exception :cljr System.Exception) _
       form)))")
 
+(def ^:private bind-repl-vars-str
+  "bind-repl-vars! carries a form's value into *1 so a later form in the same
+  block can chain off it, as RCT does. write-deftest binds the vars."
+  "(defn bind-repl-vars! [result]
+  (set! *3 *2)
+  (set! *2 *1)
+  (set! *1 result)
+  result)")
+
 (defn write-preamble
-  "Write the ns form and the error->map and eval-expectation helpers.
+  "Write the ns form and the error->map, eval-expectation and bind-repl-vars! helpers.
   The ns is tagged ^:clr-only so Kaocha skips it on the JVM."
   [w output-ns ns-syms]
   (let [requires (sort ns-syms)
@@ -442,7 +459,8 @@
                    (string/join "\n" req-lines) "))\n"
                    "\n"
                    error->map-str "\n\n"
-                   eval-expectation-str "\n\n"))))
+                   eval-expectation-str "\n\n"
+                   bind-repl-vars-str "\n\n"))))
 
 (def cli-options
   [["-s" "--src-dir DIR" "Source directory to scan (repeatable, default: src)"

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -153,8 +153,45 @@
                      block)))
          (filter seq))))
 
+(defn self-evaluating?
+  "True when x can be emitted into code position as-is. A seq evaluates as a
+  call and a symbol as a var reference, so a collection is self-evaluating only
+  when every element is."
+  [x]
+  (cond
+    (or (seq? x) (symbol? x)) false
+    (coll? x) (every? self-evaluating? x)
+    :else true))
+
+^:rct/test
+(comment
+  (self-evaluating? 42)
+  ;=> true
+
+  ;; a seq evaluates as a call
+  (self-evaluating? '(:h :c :s))
+  ;=> false
+
+  ;; a symbol evaluates as a var reference
+  (self-evaluating? 'foo)
+  ;=> false
+
+  (self-evaluating? [1 2 3])
+  ;=> true
+
+  ;; a collection is only as safe as its elements, map entries included
+  (self-evaluating? '{:a (1 2)})
+  ;=> false
+
+  (self-evaluating? [])
+  ;=> true
+  )
+
 (defn read-expectation
-  "Read expectation string into a form, handling ellipses for =>>."
+  "Read expectation string into a form, handling ellipses for =>>.
+  Returns the datum unevaluated: RCT evaluates an expectation at test time, and
+  datum->form emits that evaluation into the generated file rather than running
+  it here, so generation stays a pure function of the source."
   [{:keys [expectation-string expectation-type]} ns-sym]
   (when expectation-string
     (let [s (if (= '=>> expectation-type)
@@ -182,6 +219,12 @@
                      :expectation-type '=>}
                     'rct-clr.gen)
   ;=> nil
+
+  ;; a list expectation is not evaluated here
+  (read-expectation {:expectation-string "(+ 1 2)"
+                     :expectation-type '=>}
+                    'rct-clr.gen)
+  ;=> '(+ 1 2)
 
   ;; reader conditional resolves to :cljr branch
   (read-expectation {:expectation-string "#?(:clj :jvm :cljr :clr)"
@@ -215,21 +258,27 @@
   )
 
 (defn datum->form
-  "Convert an RCT datum to a Clojure form for the generated test."
+  "Convert an RCT datum to a Clojure form for the generated test.
+  A => expectation that is not self-evaluating goes through eval-expectation at
+  test time, so an earlier form's defs are in place by the time it evaluates."
   [{:keys [test-sexpr expectation-type] :as datum} ns-sym output-ns]
-  (let [error->map-sym (symbol (str output-ns) "error->map")]
+  (let [error->map-sym (symbol (str output-ns) "error->map")
+        eval-sym (symbol (str output-ns) "eval-expectation")
+        expectation (read-expectation datum ns-sym)]
     (case expectation-type
       ;; nil = side-effect form (def, require), emit raw
       nil test-sexpr
       => (list 'clojure.test/is
-               (list '= (read-expectation datum ns-sym) test-sexpr))
-      =>> (list 'matcho.core/assert
-                (read-expectation datum ns-sym) test-sexpr)
+               (list '= (if (self-evaluating? expectation)
+                          expectation
+                          (list eval-sym (list 'quote expectation)))
+                     test-sexpr))
+      =>> (list 'matcho.core/assert expectation test-sexpr)
       throws=>> (list 'try test-sexpr
                       (list 'clojure.test/is false "Expected exception")
                       (list 'catch 'System.Exception 'e
                             (list 'matcho.core/assert
-                                  (read-expectation datum ns-sym)
+                                  expectation
                                   (list error->map-sym 'e)))))))
 
 ^:rct/test
@@ -248,6 +297,14 @@
                'rct-clr.gen
                'test-output-ns)
   ;=> '(clojure.test/is (= 3 (+ 1 2)))
+
+  ;; => a non-self-evaluating expectation is handed to eval-expectation
+  (datum->form {:test-sexpr '(order)
+                :expectation-string "(:h :c :s :d nil)"
+                :expectation-type '=>}
+               'rct-clr.gen
+               'test-output-ns)
+  ;=> '(clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (order)))
 
   ;; =>> expectation: matcho pattern
   (datum->form {:test-sexpr '(get-status)
@@ -361,8 +418,18 @@
    :error/message #?(:clj (.getMessage e) :cljr (.Message e))
    :error/data (ex-data e)})")
 
+(def ^:private eval-expectation-str
+  "eval-expectation reproduces RCT's expectation handling: evaluate the form,
+  and compare against the form itself when evaluating it throws, which is what
+  makes a data-valued list compare as data."
+  "(defn eval-expectation [form]
+  (try
+    (eval form)
+    (catch #?(:clj Exception :cljr System.Exception) _
+      form)))")
+
 (defn write-preamble
-  "Write the ns form and error->map helper.
+  "Write the ns form and the error->map and eval-expectation helpers.
   The ns is tagged ^:clr-only so Kaocha skips it on the JVM."
   [w output-ns ns-syms]
   (let [requires (sort ns-syms)
@@ -374,7 +441,8 @@
                    "            [matcho.core]\n"
                    (string/join "\n" req-lines) "))\n"
                    "\n"
-                   error->map-str "\n\n"))))
+                   error->map-str "\n\n"
+                   eval-expectation-str "\n\n"))))
 
 (def cli-options
   [["-s" "--src-dir DIR" "Source directory to scan (repeatable, default: src)"

--- a/test/rct_clr/gen_test.clj
+++ b/test/rct_clr/gen_test.clj
@@ -280,7 +280,7 @@
         datums (mapcat identity blocks)
         valid-types #{nil '=> '=>> 'throws=>>}]
     (testing "finds all RCT blocks"
-      (is (= 6 (count blocks))))
+      (is (= 7 (count blocks))))
     (testing "every block is a non-empty seq"
       (is (every? seq blocks)))
     (testing "first block is build-resolver with exact test-sexpr"

--- a/test/rct_clr/gen_test.clj
+++ b/test/rct_clr/gen_test.clj
@@ -158,7 +158,8 @@
 (deftest write-deftest-empty-blocks-test
   (let [sw (java.io.StringWriter.)
         expected (str "(deftest some-ns-rct\n"
-                      "  (binding [*ns* (the-ns 'some.ns)]))\n\n")]
+                      "  (binding [*ns* (the-ns 'some.ns)\n"
+                      "            *1 nil, *2 nil, *3 nil, *e nil]))\n\n")]
     (gen/write-deftest sw 'some.ns [])
     (is (= expected (str sw)))))
 
@@ -234,7 +235,7 @@
         out (write-block-output block-data "meta.cljc")
         expected (str "(defn- meta-block-0 []\n"
                       "  ;; meta.cljc:5\n"
-                      "  (testing \"meta.cljc:5\" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [1 2 3] (get-items))))))\n")]
+                      "  (testing \"meta.cljc:5\" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [1 2 3] (test.output/bind-repl-vars! (get-items)))))))\n")]
     (is (= expected out))))
 
 ;; ---------------------------------------------------------------------------

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -9,83 +9,106 @@
    :error/message #?(:clj (.getMessage e) :cljr (.Message e))
    :error/data (ex-data e)})
 
+(defn eval-expectation [form]
+  (try
+    (eval form)
+    (catch #?(:clj Exception :cljr System.Exception) _
+      form)))
+
 ;; rct-clr.gen
 (defn- rct-clr-gen-rct-block-0 []
   ;; gen.cljc:41
-  (testing "gen.cljc:41" (eval (quote (clojure.test/is (= {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)} (build-resolver (quote rct-clr.gen)))))))
+  (testing "gen.cljc:41" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (build-resolver (quote rct-clr.gen)))))))
   ;; gen.cljc:56
   (eval (quote (def rct-test-bare-ns (create-ns (gensym "bare-ns-")))))
   ;; gen.cljc:57
-  (testing "gen.cljc:57" (eval (quote (clojure.test/is (= {:current (ns-name rct-test-bare-ns)} (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result)))))))
+  (testing "gen.cljc:57" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:current (ns-name rct-test-bare-ns)})) (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result)))))))
 (defn- rct-clr-gen-rct-block-1 []
   ;; gen.cljc:91
-  (testing "gen.cljc:91" (eval (quote (clojure.test/is (= (quote (.Message e)) (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:91" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen)))))))
   ;; gen.cljc:97
-  (testing "gen.cljc:97" (eval (quote (clojure.test/is (= (quote (try (foo) (catch System.Exception e (.Message e)))) (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:97" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen)))))))
   ;; gen.cljc:107
-  (testing "gen.cljc:107" (eval (quote (clojure.test/is (= (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:107" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen)))))))
   ;; gen.cljc:115
-  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (quote (+ 1 2)) (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen)))))))
   ;; gen.cljc:119
   (testing "gen.cljc:119" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen)))))))
   ;; gen.cljc:125
-  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (quote (read-string "[1 2 3]")) (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen)))))))
   ;; gen.cljc:129
   (testing "gen.cljc:129" (eval (quote (clojure.test/is (= nil (resolve-reader-conditionals (quote nil) (quote rct-clr.gen)))))))
   ;; gen.cljc:135
   (testing "gen.cljc:135" (eval (quote (clojure.test/is (= :fallback (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen))))))))
 (defn- rct-clr-gen-rct-block-2 []
-  ;; gen.cljc:171
-  (testing "gen.cljc:171" (eval (quote (clojure.test/is (= 42 (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:168
+  (testing "gen.cljc:168" (eval (quote (clojure.test/is (= true (self-evaluating? 42))))))
+  ;; gen.cljc:172
+  (testing "gen.cljc:172" (eval (quote (clojure.test/is (= false (self-evaluating? (quote (:h :c :s))))))))
   ;; gen.cljc:176
-  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= [1 2] (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))
-  ;; gen.cljc:181
-  (testing "gen.cljc:181" (eval (quote (clojure.test/is (= nil (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen)))))))
-  ;; gen.cljc:187
-  (testing "gen.cljc:187" (eval (quote (clojure.test/is (= :clr (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen)))))))
-  ;; gen.cljc:193
-  (testing "gen.cljc:193" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen)))))))
-  ;; gen.cljc:199
-  (testing "gen.cljc:199" (eval (quote (clojure.test/is (= :clojure.string/join (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen)))))))
-  ;; gen.cljc:205
-  (testing "gen.cljc:205" (eval (quote (clojure.test/is (= 3 (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:211
-  (testing "gen.cljc:211" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
+  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= false (self-evaluating? (quote foo)))))))
+  ;; gen.cljc:179
+  (testing "gen.cljc:179" (eval (quote (clojure.test/is (= true (self-evaluating? [1 2 3]))))))
+  ;; gen.cljc:183
+  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (self-evaluating? (quote {:a (1 2)})))))))
+  ;; gen.cljc:186
+  (testing "gen.cljc:186" (eval (quote (clojure.test/is (= true (self-evaluating? [])))))))
 (defn- rct-clr-gen-rct-block-3 []
-  ;; gen.cljc:238
-  (testing "gen.cljc:238" (eval (quote (clojure.test/is (= (quote (def x 1)) (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:245
-  (testing "gen.cljc:245" (eval (quote (clojure.test/is (= (quote (clojure.test/is (= 3 (+ 1 2)))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:253
-  (testing "gen.cljc:253" (eval (quote (clojure.test/is (= (quote (matcho.core/assert {:status 200} (get-status))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:261
-  (testing "gen.cljc:261" (eval (quote (clojure.test/is (= (quote (matcho.core/assert [0 1] (range 5))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:269
-  (testing "gen.cljc:269" (eval (quote (clojure.test/is (= (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))) (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:282
-  (testing "gen.cljc:282" (eval (quote (clojure.test/is (= (quote (clojure.test/is (= :clr (get-platform)))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:290
-  (testing "gen.cljc:290" (eval (quote (clojure.test/is (= (quote (clojure.test/is (= :rct-clr.gen/foo (get-type)))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:208
+  (testing "gen.cljc:208" (eval (quote (clojure.test/is (= 42 (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:213
+  (testing "gen.cljc:213" (eval (quote (clojure.test/is (= [1 2] (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:218
+  (testing "gen.cljc:218" (eval (quote (clojure.test/is (= nil (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen)))))))
+  ;; gen.cljc:224
+  (testing "gen.cljc:224" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:230
+  (testing "gen.cljc:230" (eval (quote (clojure.test/is (= :clr (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:236
+  (testing "gen.cljc:236" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:242
+  (testing "gen.cljc:242" (eval (quote (clojure.test/is (= :clojure.string/join (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen)))))))
+  ;; gen.cljc:248
+  (testing "gen.cljc:248" (eval (quote (clojure.test/is (= 3 (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:254
+  (testing "gen.cljc:254" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
 (defn- rct-clr-gen-rct-block-4 []
-  ;; gen.cljc:305
-  (testing "gen.cljc:305" (eval (quote (clojure.test/is (= "my-cool-namespace" (ns-sym->test-base (quote my.cool.namespace)))))))
-  ;; gen.cljc:308
-  (testing "gen.cljc:308" (eval (quote (clojure.test/is (= "single" (ns-sym->test-base (quote single))))))))
+  ;; gen.cljc:287
+  (testing "gen.cljc:287" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (def x 1)))) (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:294
+  (testing "gen.cljc:294" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (+ 1 2)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:302
+  (testing "gen.cljc:302" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (order)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:310
+  (testing "gen.cljc:310" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (get-status))))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:318
+  (testing "gen.cljc:318" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (range 5))))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:326
+  (testing "gen.cljc:326" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:339
+  (testing "gen.cljc:339" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (get-platform)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns)))))))
+  ;; gen.cljc:347
+  (testing "gen.cljc:347" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (get-type)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns))))))))
 (defn- rct-clr-gen-rct-block-5 []
-  ;; gen.cljc:407
-  (testing "gen.cljc:407" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-o" "out.cljc" "-n" "my.ns"]))))))
-  ;; gen.cljc:411
-  (testing "gen.cljc:411" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"]))))))
-  ;; gen.cljc:415
-  (testing "gen.cljc:415" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (validate-opts ["-n" "my.ns"]))))))
-  ;; gen.cljc:419
-  (testing "gen.cljc:419" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (validate-opts ["-o" "out.cljc"]))))))
-  ;; gen.cljc:423
-  (testing "gen.cljc:423" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (validate-opts []))))))
-  ;; gen.cljc:427
-  (testing "gen.cljc:427" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["--bogus"]) :errors))))))
-  ;; gen.cljc:430
-  (testing "gen.cljc:430" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["-h"]) :help)))))))
+  ;; gen.cljc:362
+  (testing "gen.cljc:362" (eval (quote (clojure.test/is (= "my-cool-namespace" (ns-sym->test-base (quote my.cool.namespace)))))))
+  ;; gen.cljc:365
+  (testing "gen.cljc:365" (eval (quote (clojure.test/is (= "single" (ns-sym->test-base (quote single))))))))
+(defn- rct-clr-gen-rct-block-6 []
+  ;; gen.cljc:475
+  (testing "gen.cljc:475" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-o" "out.cljc" "-n" "my.ns"]))))))
+  ;; gen.cljc:479
+  (testing "gen.cljc:479" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"]))))))
+  ;; gen.cljc:483
+  (testing "gen.cljc:483" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (validate-opts ["-n" "my.ns"]))))))
+  ;; gen.cljc:487
+  (testing "gen.cljc:487" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (validate-opts ["-o" "out.cljc"]))))))
+  ;; gen.cljc:491
+  (testing "gen.cljc:491" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (validate-opts []))))))
+  ;; gen.cljc:495
+  (testing "gen.cljc:495" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["--bogus"]) :errors))))))
+  ;; gen.cljc:498
+  (testing "gen.cljc:498" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["-h"]) :help)))))))
 (deftest rct-clr-gen-rct
   (binding [*ns* (the-ns 'rct-clr.gen)]
     (rct-clr-gen-rct-block-0)
@@ -93,5 +116,6 @@
     (rct-clr-gen-rct-block-2)
     (rct-clr-gen-rct-block-3)
     (rct-clr-gen-rct-block-4)
-    (rct-clr-gen-rct-block-5)))
+    (rct-clr-gen-rct-block-5)
+    (rct-clr-gen-rct-block-6)))
 

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -15,102 +15,109 @@
     (catch #?(:clj Exception :cljr System.Exception) _
       form)))
 
+(defn bind-repl-vars! [result]
+  (set! *3 *2)
+  (set! *2 *1)
+  (set! *1 result)
+  result)
+
 ;; rct-clr.gen
 (defn- rct-clr-gen-rct-block-0 []
   ;; gen.cljc:41
-  (testing "gen.cljc:41" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (build-resolver (quote rct-clr.gen)))))))
+  (testing "gen.cljc:41" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (rct-clr.rct-generated-test/bind-repl-vars! (build-resolver (quote rct-clr.gen))))))))
   ;; gen.cljc:56
-  (eval (quote (def rct-test-bare-ns (create-ns (gensym "bare-ns-")))))
+  (eval (quote (rct-clr.rct-generated-test/bind-repl-vars! (def rct-test-bare-ns (create-ns (gensym "bare-ns-"))))))
   ;; gen.cljc:57
-  (testing "gen.cljc:57" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:current (ns-name rct-test-bare-ns)})) (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result)))))))
+  (testing "gen.cljc:57" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:current (ns-name rct-test-bare-ns)})) (rct-clr.rct-generated-test/bind-repl-vars! (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result))))))))
 (defn- rct-clr-gen-rct-block-1 []
   ;; gen.cljc:91
-  (testing "gen.cljc:91" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:91" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen))))))))
   ;; gen.cljc:97
-  (testing "gen.cljc:97" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:97" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen))))))))
   ;; gen.cljc:107
-  (testing "gen.cljc:107" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:107" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
   ;; gen.cljc:115
-  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
   ;; gen.cljc:119
-  (testing "gen.cljc:119" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen)))))))
+  (testing "gen.cljc:119" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
   ;; gen.cljc:125
-  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
   ;; gen.cljc:129
-  (testing "gen.cljc:129" (eval (quote (clojure.test/is (= nil (resolve-reader-conditionals (quote nil) (quote rct-clr.gen)))))))
+  (testing "gen.cljc:129" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
   ;; gen.cljc:135
-  (testing "gen.cljc:135" (eval (quote (clojure.test/is (= :fallback (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen))))))))
+  (testing "gen.cljc:135" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
 (defn- rct-clr-gen-rct-block-2 []
   ;; gen.cljc:168
-  (testing "gen.cljc:168" (eval (quote (clojure.test/is (= true (self-evaluating? 42))))))
+  (testing "gen.cljc:168" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
   ;; gen.cljc:172
-  (testing "gen.cljc:172" (eval (quote (clojure.test/is (= false (self-evaluating? (quote (:h :c :s))))))))
+  (testing "gen.cljc:172" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
   ;; gen.cljc:176
-  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= false (self-evaluating? (quote foo)))))))
+  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
   ;; gen.cljc:179
-  (testing "gen.cljc:179" (eval (quote (clojure.test/is (= true (self-evaluating? [1 2 3]))))))
+  (testing "gen.cljc:179" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
   ;; gen.cljc:183
-  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (self-evaluating? (quote {:a (1 2)})))))))
+  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
   ;; gen.cljc:186
-  (testing "gen.cljc:186" (eval (quote (clojure.test/is (= true (self-evaluating? [])))))))
+  (testing "gen.cljc:186" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
 (defn- rct-clr-gen-rct-block-3 []
   ;; gen.cljc:208
-  (testing "gen.cljc:208" (eval (quote (clojure.test/is (= 42 (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:208" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
   ;; gen.cljc:213
-  (testing "gen.cljc:213" (eval (quote (clojure.test/is (= [1 2] (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:213" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
   ;; gen.cljc:218
-  (testing "gen.cljc:218" (eval (quote (clojure.test/is (= nil (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:218" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
   ;; gen.cljc:224
-  (testing "gen.cljc:224" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:224" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
   ;; gen.cljc:230
-  (testing "gen.cljc:230" (eval (quote (clojure.test/is (= :clr (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:230" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
   ;; gen.cljc:236
-  (testing "gen.cljc:236" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:236" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
   ;; gen.cljc:242
-  (testing "gen.cljc:242" (eval (quote (clojure.test/is (= :clojure.string/join (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen)))))))
+  (testing "gen.cljc:242" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
   ;; gen.cljc:248
-  (testing "gen.cljc:248" (eval (quote (clojure.test/is (= 3 (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
+  (testing "gen.cljc:248" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
   ;; gen.cljc:254
-  (testing "gen.cljc:254" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
+  (testing "gen.cljc:254" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
 (defn- rct-clr-gen-rct-block-4 []
-  ;; gen.cljc:287
-  (testing "gen.cljc:287" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (def x 1)))) (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:294
-  (testing "gen.cljc:294" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (+ 1 2)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:302
-  (testing "gen.cljc:302" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (order)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:310
-  (testing "gen.cljc:310" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (get-status))))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:318
-  (testing "gen.cljc:318" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (range 5))))) (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:326
-  (testing "gen.cljc:326" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:339
-  (testing "gen.cljc:339" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (get-platform)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns)))))))
-  ;; gen.cljc:347
-  (testing "gen.cljc:347" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (get-type)))))) (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:291
+  (testing "gen.cljc:291" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:298
+  (testing "gen.cljc:298" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:306
+  (testing "gen.cljc:306" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:314
+  (testing "gen.cljc:314" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:322
+  (testing "gen.cljc:322" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:330
+  (testing "gen.cljc:330" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:344
+  (testing "gen.cljc:344" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:352
+  (testing "gen.cljc:352" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
 (defn- rct-clr-gen-rct-block-5 []
-  ;; gen.cljc:362
-  (testing "gen.cljc:362" (eval (quote (clojure.test/is (= "my-cool-namespace" (ns-sym->test-base (quote my.cool.namespace)))))))
-  ;; gen.cljc:365
-  (testing "gen.cljc:365" (eval (quote (clojure.test/is (= "single" (ns-sym->test-base (quote single))))))))
+  ;; gen.cljc:367
+  (testing "gen.cljc:367" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
+  ;; gen.cljc:370
+  (testing "gen.cljc:370" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
 (defn- rct-clr-gen-rct-block-6 []
-  ;; gen.cljc:475
-  (testing "gen.cljc:475" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-o" "out.cljc" "-n" "my.ns"]))))))
-  ;; gen.cljc:479
-  (testing "gen.cljc:479" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"]))))))
-  ;; gen.cljc:483
-  (testing "gen.cljc:483" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (validate-opts ["-n" "my.ns"]))))))
-  ;; gen.cljc:487
-  (testing "gen.cljc:487" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (validate-opts ["-o" "out.cljc"]))))))
-  ;; gen.cljc:491
-  (testing "gen.cljc:491" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (validate-opts []))))))
-  ;; gen.cljc:495
-  (testing "gen.cljc:495" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["--bogus"]) :errors))))))
-  ;; gen.cljc:498
-  (testing "gen.cljc:498" (eval (quote (clojure.test/is (= true (contains? (validate-opts ["-h"]) :help)))))))
+  ;; gen.cljc:493
+  (testing "gen.cljc:493" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:497
+  (testing "gen.cljc:497" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:501
+  (testing "gen.cljc:501" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
+  ;; gen.cljc:505
+  (testing "gen.cljc:505" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
+  ;; gen.cljc:509
+  (testing "gen.cljc:509" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
+  ;; gen.cljc:513
+  (testing "gen.cljc:513" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
+  ;; gen.cljc:516
+  (testing "gen.cljc:516" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
 (deftest rct-clr-gen-rct
-  (binding [*ns* (the-ns 'rct-clr.gen)]
+  (binding [*ns* (the-ns 'rct-clr.gen)
+            *1 nil, *2 nil, *3 nil, *e nil]
     (rct-clr-gen-rct-block-0)
     (rct-clr-gen-rct-block-1)
     (rct-clr-gen-rct-block-2)

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -10,6 +10,12 @@
    :error/message #?(:clj (.getMessage e) :cljr (.Message e))
    :error/data (ex-data e)})
 
+(defn eval-expectation [form]
+  (try
+    (eval form)
+    (catch #?(:clj Exception :cljr System.Exception) _
+      form)))
+
 ;; rct-clr.sample
 (defn- rct-clr-sample-rct-block-0 []
   ;; sample.cljc:17
@@ -25,80 +31,89 @@
   ;; sample.cljc:33
   (testing "sample.cljc:33" (eval (quote (clojure.test/is (= 21 (add doubled 1)))))))
 (defn- rct-clr-sample-rct-block-1 []
-  ;; sample.cljc:44
-  (testing "sample.cljc:44" (eval (quote (clojure.test/is (= "Hello, World!" (greet "World"))))))
-  ;; sample.cljc:47
-  (testing "sample.cljc:47" (eval (quote (clojure.test/is (= "HELLO, TEST!" (str/upper-case (greet "test")))))))
-  ;; sample.cljc:50
-  (testing "sample.cljc:50" (eval (quote (clojure.test/is (= "a, b, c" (str/join ", " ["a" "b" "c"]))))))
-  ;; sample.cljc:53
-  (testing "sample.cljc:53" (eval (quote (clojure.test/is (= true (str/blank? ""))))))
+  ;; sample.cljc:48
+  (testing "sample.cljc:48" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (:h :c :s :d))) (suits))))))
+  ;; sample.cljc:52
+  (testing "sample.cljc:52" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (1 2 3))) (map inc (range 3)))))))
   ;; sample.cljc:56
-  (testing "sample.cljc:56" (eval (quote (clojure.test/is (= false (str/blank? "x")))))))
+  (testing "sample.cljc:56" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote foo)) (a-symbol))))))
+  ;; sample.cljc:60
+  (testing "sample.cljc:60" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (+ 2 2))) (count (suits))))))))
 (defn- rct-clr-sample-rct-block-2 []
-  ;; sample.cljc:68
-  (testing "sample.cljc:68" (eval (quote (clojure.test/is (= :clr (platform)))))))
+  ;; sample.cljc:71
+  (testing "sample.cljc:71" (eval (quote (clojure.test/is (= "Hello, World!" (greet "World"))))))
+  ;; sample.cljc:74
+  (testing "sample.cljc:74" (eval (quote (clojure.test/is (= "HELLO, TEST!" (str/upper-case (greet "test")))))))
+  ;; sample.cljc:77
+  (testing "sample.cljc:77" (eval (quote (clojure.test/is (= "a, b, c" (str/join ", " ["a" "b" "c"]))))))
+  ;; sample.cljc:80
+  (testing "sample.cljc:80" (eval (quote (clojure.test/is (= true (str/blank? ""))))))
+  ;; sample.cljc:83
+  (testing "sample.cljc:83" (eval (quote (clojure.test/is (= false (str/blank? "x")))))))
 (defn- rct-clr-sample-rct-block-3 []
-  ;; sample.cljc:79
-  (testing "sample.cljc:79" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (my-type)))))))
+  ;; sample.cljc:95
+  (testing "sample.cljc:95" (eval (quote (clojure.test/is (= :clr (platform)))))))
 (defn- rct-clr-sample-rct-block-4 []
-  ;; sample.cljc:92
-  (testing "sample.cljc:92" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (alias-kws)))))))
+  ;; sample.cljc:106
+  (testing "sample.cljc:106" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (my-type)))))))
 (defn- rct-clr-sample-rct-block-5 []
-  ;; sample.cljc:109
-  (testing "sample.cljc:109" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (user-profile 1 "Alice"))))))
-  ;; sample.cljc:116
-  (testing "sample.cljc:116" (eval (quote (clojure.test/is (= "dark" (get-in (user-profile 1 "Alice") [:settings :theme])))))))
+  ;; sample.cljc:119
+  (testing "sample.cljc:119" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (alias-kws)))))))
 (defn- rct-clr-sample-rct-block-6 []
-  ;; sample.cljc:132
-  (testing "sample.cljc:132" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (api-response {:users []})))))
   ;; sample.cljc:136
-  (testing "sample.cljc:136" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (api-response {:count 5}))))))
+  (testing "sample.cljc:136" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (user-profile 1 "Alice"))))))
+  ;; sample.cljc:143
+  (testing "sample.cljc:143" (eval (quote (clojure.test/is (= "dark" (get-in (user-profile 1 "Alice") [:settings :theme])))))))
 (defn- rct-clr-sample-rct-block-7 []
-  ;; sample.cljc:151
-  (testing "sample.cljc:151" (eval (quote (matcho.core/assert [{:name "a"}] (scored-items)))))
-  ;; sample.cljc:155
-  (testing "sample.cljc:155" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (mapv :name (scored-items)))))))
+  ;; sample.cljc:159
+  (testing "sample.cljc:159" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (api-response {:users []})))))
+  ;; sample.cljc:163
+  (testing "sample.cljc:163" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (api-response {:count 5}))))))
 (defn- rct-clr-sample-rct-block-8 []
-  ;; sample.cljc:166
-  (testing "sample.cljc:166" (eval (quote (matcho.core/assert [0 1 1 2] (fibonacci 7)))))
-  ;; sample.cljc:169
-  (testing "sample.cljc:169" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (fibonacci 3))))))
+  ;; sample.cljc:178
+  (testing "sample.cljc:178" (eval (quote (matcho.core/assert [{:name "a"}] (scored-items)))))
+  ;; sample.cljc:182
+  (testing "sample.cljc:182" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (mapv :name (scored-items)))))))
 (defn- rct-clr-sample-rct-block-9 []
-  ;; sample.cljc:180
-  (testing "sample.cljc:180" (eval (quote (clojure.test/is (= #{:c :b} (common-tags #{:c :b :a} #{:c :b :d}))))))
-  ;; sample.cljc:183
-  (testing "sample.cljc:183" (eval (quote (clojure.test/is (= #{:b :a} (set/union #{:a} #{:b})))))))
+  ;; sample.cljc:193
+  (testing "sample.cljc:193" (eval (quote (matcho.core/assert [0 1 1 2] (fibonacci 7)))))
+  ;; sample.cljc:196
+  (testing "sample.cljc:196" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (fibonacci 3))))))
 (defn- rct-clr-sample-rct-block-10 []
-  ;; sample.cljc:198
-  (testing "sample.cljc:198" (eval (quote (clojure.test/is (= "alice bob" (normalize-name "  Alice BOB  "))))))
-  ;; sample.cljc:201
-  (testing "sample.cljc:201" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (make-user "  Alice BOB  ")))))))
+  ;; sample.cljc:207
+  (testing "sample.cljc:207" (eval (quote (clojure.test/is (= #{:c :b} (common-tags #{:c :b :a} #{:c :b :d}))))))
+  ;; sample.cljc:210
+  (testing "sample.cljc:210" (eval (quote (clojure.test/is (= #{:b :a} (set/union #{:a} #{:b})))))))
 (defn- rct-clr-sample-rct-block-11 []
-  ;; sample.cljc:213
-  (testing "sample.cljc:213" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:225
+  (testing "sample.cljc:225" (eval (quote (clojure.test/is (= "alice bob" (normalize-name "  Alice BOB  "))))))
+  ;; sample.cljc:228
+  (testing "sample.cljc:228" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (make-user "  Alice BOB  ")))))))
 (defn- rct-clr-sample-rct-block-12 []
-  ;; sample.cljc:227
-  (testing "sample.cljc:227" (eval (quote (clojure.test/is (= {:host "localhost"} (parse-config {:host "localhost"}))))))
-  ;; sample.cljc:231
-  (testing "sample.cljc:231" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
-  ;; sample.cljc:235
-  (testing "sample.cljc:235" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:240
+  (testing "sample.cljc:240" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-13 []
-  ;; sample.cljc:251
-  (testing "sample.cljc:251" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (stringify-keys {:b {:c 2}, :a 1})))))))
-(defn- rct-clr-sample-rct-block-14 []
+  ;; sample.cljc:254
+  (testing "sample.cljc:254" (eval (quote (clojure.test/is (= {:host "localhost"} (parse-config {:host "localhost"}))))))
+  ;; sample.cljc:258
+  (testing "sample.cljc:258" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
   ;; sample.cljc:262
-  (testing "sample.cljc:262" (eval (quote (clojure.test/is (= true (truthy? 1))))))
-  ;; sample.cljc:265
-  (testing "sample.cljc:265" (eval (quote (clojure.test/is (= false (truthy? nil))))))
-  ;; sample.cljc:268
-  (testing "sample.cljc:268" (eval (quote (clojure.test/is (= false (truthy? false))))))
-  ;; sample.cljc:271
-  (testing "sample.cljc:271" (eval (quote (clojure.test/is (= true (nil? nil)))))))
+  (testing "sample.cljc:262" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
+(defn- rct-clr-sample-rct-block-14 []
+  ;; sample.cljc:278
+  (testing "sample.cljc:278" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (stringify-keys {:b {:c 2}, :a 1})))))))
 (defn- rct-clr-sample-rct-block-15 []
-  ;; sample.cljc:282
-  (testing "sample.cljc:282" (eval (quote (clojure.test/is (= {} (ex-data (make-error "boom"))))))))
+  ;; sample.cljc:289
+  (testing "sample.cljc:289" (eval (quote (clojure.test/is (= true (truthy? 1))))))
+  ;; sample.cljc:292
+  (testing "sample.cljc:292" (eval (quote (clojure.test/is (= false (truthy? nil))))))
+  ;; sample.cljc:295
+  (testing "sample.cljc:295" (eval (quote (clojure.test/is (= false (truthy? false))))))
+  ;; sample.cljc:298
+  (testing "sample.cljc:298" (eval (quote (clojure.test/is (= true (nil? nil)))))))
+(defn- rct-clr-sample-rct-block-16 []
+  ;; sample.cljc:309
+  (testing "sample.cljc:309" (eval (quote (clojure.test/is (= {} (ex-data (make-error "boom"))))))))
 (deftest rct-clr-sample-rct
   (binding [*ns* (the-ns 'rct-clr.sample)]
     (rct-clr-sample-rct-block-0)
@@ -116,7 +131,8 @@
     (rct-clr-sample-rct-block-12)
     (rct-clr-sample-rct-block-13)
     (rct-clr-sample-rct-block-14)
-    (rct-clr-sample-rct-block-15)))
+    (rct-clr-sample-rct-block-15)
+    (rct-clr-sample-rct-block-16)))
 
 ;; rct-clr.sample-clr
 (defn- rct-clr-sample-clr-rct-block-0 []

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -16,106 +16,120 @@
     (catch #?(:clj Exception :cljr System.Exception) _
       form)))
 
+(defn bind-repl-vars! [result]
+  (set! *3 *2)
+  (set! *2 *1)
+  (set! *1 result)
+  result)
+
 ;; rct-clr.sample
 (defn- rct-clr-sample-rct-block-0 []
   ;; sample.cljc:17
-  (testing "sample.cljc:17" (eval (quote (clojure.test/is (= 3 (add 1 2))))))
+  (testing "sample.cljc:17" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (add 1 2)))))))
   ;; sample.cljc:20
-  (testing "sample.cljc:20" (eval (quote (clojure.test/is (= 0 (add -1 1))))))
+  (testing "sample.cljc:20" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (add -1 1)))))))
   ;; sample.cljc:24
-  (eval (quote (def base-val 10)))
+  (eval (quote (rct-clr.sample-generated-test/bind-repl-vars! (def base-val 10))))
   ;; sample.cljc:27
-  (testing "sample.cljc:27" (eval (quote (clojure.test/is (= 15 (add base-val 5))))))
+  (testing "sample.cljc:27" (eval (quote (clojure.test/is (= 15 (rct-clr.sample-generated-test/bind-repl-vars! (add base-val 5)))))))
   ;; sample.cljc:31
-  (eval (quote (def doubled (* base-val 2))))
+  (eval (quote (rct-clr.sample-generated-test/bind-repl-vars! (def doubled (* base-val 2)))))
   ;; sample.cljc:33
-  (testing "sample.cljc:33" (eval (quote (clojure.test/is (= 21 (add doubled 1)))))))
+  (testing "sample.cljc:33" (eval (quote (clojure.test/is (= 21 (rct-clr.sample-generated-test/bind-repl-vars! (add doubled 1))))))))
 (defn- rct-clr-sample-rct-block-1 []
   ;; sample.cljc:48
-  (testing "sample.cljc:48" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (:h :c :s :d))) (suits))))))
+  (testing "sample.cljc:48" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (:h :c :s :d))) (rct-clr.sample-generated-test/bind-repl-vars! (suits)))))))
   ;; sample.cljc:52
-  (testing "sample.cljc:52" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (1 2 3))) (map inc (range 3)))))))
+  (testing "sample.cljc:52" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (1 2 3))) (rct-clr.sample-generated-test/bind-repl-vars! (map inc (range 3))))))))
   ;; sample.cljc:56
-  (testing "sample.cljc:56" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote foo)) (a-symbol))))))
+  (testing "sample.cljc:56" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote foo)) (rct-clr.sample-generated-test/bind-repl-vars! (a-symbol)))))))
   ;; sample.cljc:60
-  (testing "sample.cljc:60" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (+ 2 2))) (count (suits))))))))
+  (testing "sample.cljc:60" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (+ 2 2))) (rct-clr.sample-generated-test/bind-repl-vars! (count (suits)))))))))
 (defn- rct-clr-sample-rct-block-2 []
   ;; sample.cljc:71
-  (testing "sample.cljc:71" (eval (quote (clojure.test/is (= "Hello, World!" (greet "World"))))))
-  ;; sample.cljc:74
-  (testing "sample.cljc:74" (eval (quote (clojure.test/is (= "HELLO, TEST!" (str/upper-case (greet "test")))))))
-  ;; sample.cljc:77
-  (testing "sample.cljc:77" (eval (quote (clojure.test/is (= "a, b, c" (str/join ", " ["a" "b" "c"]))))))
-  ;; sample.cljc:80
-  (testing "sample.cljc:80" (eval (quote (clojure.test/is (= true (str/blank? ""))))))
-  ;; sample.cljc:83
-  (testing "sample.cljc:83" (eval (quote (clojure.test/is (= false (str/blank? "x")))))))
+  (testing "sample.cljc:71" (eval (quote (clojure.test/is (= [1 2 3] (rct-clr.sample-generated-test/bind-repl-vars! (stack-push [1 2] 3)))))))
+  ;; sample.cljc:75
+  (testing "sample.cljc:75" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (count *1)))))))
+  ;; sample.cljc:79
+  (testing "sample.cljc:79" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (peek *2))))))))
 (defn- rct-clr-sample-rct-block-3 []
-  ;; sample.cljc:95
-  (testing "sample.cljc:95" (eval (quote (clojure.test/is (= :clr (platform)))))))
+  ;; sample.cljc:90
+  (testing "sample.cljc:90" (eval (quote (clojure.test/is (= "Hello, World!" (rct-clr.sample-generated-test/bind-repl-vars! (greet "World")))))))
+  ;; sample.cljc:93
+  (testing "sample.cljc:93" (eval (quote (clojure.test/is (= "HELLO, TEST!" (rct-clr.sample-generated-test/bind-repl-vars! (str/upper-case (greet "test"))))))))
+  ;; sample.cljc:96
+  (testing "sample.cljc:96" (eval (quote (clojure.test/is (= "a, b, c" (rct-clr.sample-generated-test/bind-repl-vars! (str/join ", " ["a" "b" "c"])))))))
+  ;; sample.cljc:99
+  (testing "sample.cljc:99" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "")))))))
+  ;; sample.cljc:102
+  (testing "sample.cljc:102" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "x"))))))))
 (defn- rct-clr-sample-rct-block-4 []
-  ;; sample.cljc:106
-  (testing "sample.cljc:106" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (my-type)))))))
+  ;; sample.cljc:114
+  (testing "sample.cljc:114" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! (platform))))))))
 (defn- rct-clr-sample-rct-block-5 []
-  ;; sample.cljc:119
-  (testing "sample.cljc:119" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (alias-kws)))))))
+  ;; sample.cljc:125
+  (testing "sample.cljc:125" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (rct-clr.sample-generated-test/bind-repl-vars! (my-type))))))))
 (defn- rct-clr-sample-rct-block-6 []
-  ;; sample.cljc:136
-  (testing "sample.cljc:136" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (user-profile 1 "Alice"))))))
-  ;; sample.cljc:143
-  (testing "sample.cljc:143" (eval (quote (clojure.test/is (= "dark" (get-in (user-profile 1 "Alice") [:settings :theme])))))))
+  ;; sample.cljc:138
+  (testing "sample.cljc:138" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (rct-clr.sample-generated-test/bind-repl-vars! (alias-kws))))))))
 (defn- rct-clr-sample-rct-block-7 []
-  ;; sample.cljc:159
-  (testing "sample.cljc:159" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (api-response {:users []})))))
-  ;; sample.cljc:163
-  (testing "sample.cljc:163" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (api-response {:count 5}))))))
+  ;; sample.cljc:155
+  (testing "sample.cljc:155" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (rct-clr.sample-generated-test/bind-repl-vars! (user-profile 1 "Alice")))))))
+  ;; sample.cljc:162
+  (testing "sample.cljc:162" (eval (quote (clojure.test/is (= "dark" (rct-clr.sample-generated-test/bind-repl-vars! (get-in (user-profile 1 "Alice") [:settings :theme]))))))))
 (defn- rct-clr-sample-rct-block-8 []
   ;; sample.cljc:178
-  (testing "sample.cljc:178" (eval (quote (matcho.core/assert [{:name "a"}] (scored-items)))))
+  (testing "sample.cljc:178" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:users []}))))))
   ;; sample.cljc:182
-  (testing "sample.cljc:182" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (mapv :name (scored-items)))))))
+  (testing "sample.cljc:182" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:count 5})))))))
 (defn- rct-clr-sample-rct-block-9 []
-  ;; sample.cljc:193
-  (testing "sample.cljc:193" (eval (quote (matcho.core/assert [0 1 1 2] (fibonacci 7)))))
-  ;; sample.cljc:196
-  (testing "sample.cljc:196" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (fibonacci 3))))))
+  ;; sample.cljc:197
+  (testing "sample.cljc:197" (eval (quote (matcho.core/assert [{:name "a"}] (rct-clr.sample-generated-test/bind-repl-vars! (scored-items))))))
+  ;; sample.cljc:201
+  (testing "sample.cljc:201" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (rct-clr.sample-generated-test/bind-repl-vars! (mapv :name (scored-items))))))))
 (defn- rct-clr-sample-rct-block-10 []
-  ;; sample.cljc:207
-  (testing "sample.cljc:207" (eval (quote (clojure.test/is (= #{:c :b} (common-tags #{:c :b :a} #{:c :b :d}))))))
-  ;; sample.cljc:210
-  (testing "sample.cljc:210" (eval (quote (clojure.test/is (= #{:b :a} (set/union #{:a} #{:b})))))))
+  ;; sample.cljc:212
+  (testing "sample.cljc:212" (eval (quote (matcho.core/assert [0 1 1 2] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 7))))))
+  ;; sample.cljc:215
+  (testing "sample.cljc:215" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 3)))))))
 (defn- rct-clr-sample-rct-block-11 []
-  ;; sample.cljc:225
-  (testing "sample.cljc:225" (eval (quote (clojure.test/is (= "alice bob" (normalize-name "  Alice BOB  "))))))
-  ;; sample.cljc:228
-  (testing "sample.cljc:228" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (make-user "  Alice BOB  ")))))))
+  ;; sample.cljc:226
+  (testing "sample.cljc:226" (eval (quote (clojure.test/is (= #{:c :b} (rct-clr.sample-generated-test/bind-repl-vars! (common-tags #{:c :b :a} #{:c :b :d})))))))
+  ;; sample.cljc:229
+  (testing "sample.cljc:229" (eval (quote (clojure.test/is (= #{:b :a} (rct-clr.sample-generated-test/bind-repl-vars! (set/union #{:a} #{:b}))))))))
 (defn- rct-clr-sample-rct-block-12 []
-  ;; sample.cljc:240
-  (testing "sample.cljc:240" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:244
+  (testing "sample.cljc:244" (eval (quote (clojure.test/is (= "alice bob" (rct-clr.sample-generated-test/bind-repl-vars! (normalize-name "  Alice BOB  ")))))))
+  ;; sample.cljc:247
+  (testing "sample.cljc:247" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (rct-clr.sample-generated-test/bind-repl-vars! (make-user "  Alice BOB  "))))))))
 (defn- rct-clr-sample-rct-block-13 []
-  ;; sample.cljc:254
-  (testing "sample.cljc:254" (eval (quote (clojure.test/is (= {:host "localhost"} (parse-config {:host "localhost"}))))))
-  ;; sample.cljc:258
-  (testing "sample.cljc:258" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
-  ;; sample.cljc:262
-  (testing "sample.cljc:262" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:259
+  (testing "sample.cljc:259" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-14 []
-  ;; sample.cljc:278
-  (testing "sample.cljc:278" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (stringify-keys {:b {:c 2}, :a 1})))))))
+  ;; sample.cljc:273
+  (testing "sample.cljc:273" (eval (quote (clojure.test/is (= {:host "localhost"} (rct-clr.sample-generated-test/bind-repl-vars! (parse-config {:host "localhost"})))))))
+  ;; sample.cljc:277
+  (testing "sample.cljc:277" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
+  ;; sample.cljc:281
+  (testing "sample.cljc:281" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-15 []
-  ;; sample.cljc:289
-  (testing "sample.cljc:289" (eval (quote (clojure.test/is (= true (truthy? 1))))))
-  ;; sample.cljc:292
-  (testing "sample.cljc:292" (eval (quote (clojure.test/is (= false (truthy? nil))))))
-  ;; sample.cljc:295
-  (testing "sample.cljc:295" (eval (quote (clojure.test/is (= false (truthy? false))))))
-  ;; sample.cljc:298
-  (testing "sample.cljc:298" (eval (quote (clojure.test/is (= true (nil? nil)))))))
+  ;; sample.cljc:297
+  (testing "sample.cljc:297" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (rct-clr.sample-generated-test/bind-repl-vars! (stringify-keys {:b {:c 2}, :a 1}))))))))
 (defn- rct-clr-sample-rct-block-16 []
-  ;; sample.cljc:309
-  (testing "sample.cljc:309" (eval (quote (clojure.test/is (= {} (ex-data (make-error "boom"))))))))
+  ;; sample.cljc:308
+  (testing "sample.cljc:308" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (truthy? 1)))))))
+  ;; sample.cljc:311
+  (testing "sample.cljc:311" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? nil)))))))
+  ;; sample.cljc:314
+  (testing "sample.cljc:314" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? false)))))))
+  ;; sample.cljc:317
+  (testing "sample.cljc:317" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (nil? nil))))))))
+(defn- rct-clr-sample-rct-block-17 []
+  ;; sample.cljc:328
+  (testing "sample.cljc:328" (eval (quote (clojure.test/is (= {} (rct-clr.sample-generated-test/bind-repl-vars! (ex-data (make-error "boom")))))))))
 (deftest rct-clr-sample-rct
-  (binding [*ns* (the-ns 'rct-clr.sample)]
+  (binding [*ns* (the-ns 'rct-clr.sample)
+            *1 nil, *2 nil, *3 nil, *e nil]
     (rct-clr-sample-rct-block-0)
     (rct-clr-sample-rct-block-1)
     (rct-clr-sample-rct-block-2)
@@ -132,19 +146,21 @@
     (rct-clr-sample-rct-block-13)
     (rct-clr-sample-rct-block-14)
     (rct-clr-sample-rct-block-15)
-    (rct-clr-sample-rct-block-16)))
+    (rct-clr-sample-rct-block-16)
+    (rct-clr-sample-rct-block-17)))
 
 ;; rct-clr.sample-clr
 (defn- rct-clr-sample-clr-rct-block-0 []
   ;; sample_clr.cljc:14
-  (testing "sample_clr.cljc:14" (eval (quote (clojure.test/is (= "boom" (.Message (make-error "boom")))))))
+  (testing "sample_clr.cljc:14" (eval (quote (clojure.test/is (= "boom" (rct-clr.sample-generated-test/bind-repl-vars! (.Message (make-error "boom"))))))))
   ;; sample_clr.cljc:18
-  (testing "sample_clr.cljc:18" (eval (quote (clojure.test/is (= "boom" (.Message (make-error "boom")))))))
+  (testing "sample_clr.cljc:18" (eval (quote (clojure.test/is (= "boom" (rct-clr.sample-generated-test/bind-repl-vars! (.Message (make-error "boom"))))))))
   ;; sample_clr.cljc:22
-  (testing "sample_clr.cljc:22" (eval (quote (clojure.test/is (= :clr :clr)))))
+  (testing "sample_clr.cljc:22" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! :clr))))))
   ;; sample_clr.cljc:26
-  (testing "sample_clr.cljc:26" (eval (quote (clojure.test/is (= "error: boom" (str "error: " (.Message (make-error "boom")))))))))
+  (testing "sample_clr.cljc:26" (eval (quote (clojure.test/is (= "error: boom" (rct-clr.sample-generated-test/bind-repl-vars! (str "error: " (.Message (make-error "boom"))))))))))
 (deftest rct-clr-sample-clr-rct
-  (binding [*ns* (the-ns 'rct-clr.sample-clr)]
+  (binding [*ns* (the-ns 'rct-clr.sample-clr)
+            *1 nil, *2 nil, *3 nil, *e nil]
     (rct-clr-sample-clr-rct-block-0)))
 


### PR DESCRIPTION
Closes #13, Closes #14
---

- `=>` expectations go through an `eval-expectation` helper in the generated file, so a list expectation compares as data instead of being called
- `bind-repl-vars!` carries each form's value into `*1`; the generated `deftest` binds `*1` `*2` `*3` `*e`
- `nrepl/nrepl` declared in `:dev`, which cider-nrepl 0.58.0 stopped providing
- Dependency and CI action bumps
- `examples/rct_clr/sample.cljc` gains seq, symbol and `*1` cases, so both runners exercise them
