### PR TITLE
fix(gen): scan .clj files and resolve ::alias/kw in test expressions

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -1,0 +1,13 @@
+---
+name: Problem
+about: Report something that is wrong
+title: ''
+---
+
+## Problem
+
+What is wrong. A minimal reproducing code block, the command that surfaces it, the output, and permalinks to the code.
+
+## Suggestion
+
+Optional. The concrete change as a code block, and why. Drop the section when you have none.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Closes #<issue-number>
+---
+
+- First change description
+- Second change description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to rct-clr are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- The generator scans `.clj` files alongside `.cljc`, so a `^:rct/test` block in a `.clj` file becomes a generated test instead of being skipped ([#17](https://github.com/flybot-sg/rct-clr/issues/17))
+- An `::alias/kw` in a test expression keeps its namespace in the generated test; the generator dropped the alias and emitted `:kw`, which then failed on the CLR ([#18](https://github.com/flybot-sg/rct-clr/issues/18))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,57 @@
 # Contributing
 
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), with the stylistic rules of [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional). The changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Filing issues
 
 An issue is a **problem statement**. The title says what is wrong, the body shows it, and an optional suggestion proposes a fix.
 
-Phrase the title as the problem, not the solution:
+### Title
+
+Phrase the title as the problem, not the solution.
 
 - Good: `A => expectation written as a list is called as a function instead of compared as data`
 - Bad: `Quote list expectations in datum->form`
 
-Body:
+### Body
 
     ## Problem
 
-    A minimal reproducing block, the command that surfaces it, and the output.
+    What is wrong. A minimal reproducing code block, the command that surfaces it, the output, and permalinks to the code.
 
     ## Suggestion
 
     Optional. The concrete change as a code block, and why. Drop the section when you have none.
 
-Show, do not describe. A block someone can paste beats a paragraph.
+Show, do not describe. A block someone can paste beats a paragraph. Two sections only.
 
 ## Pull requests
 
-PRs target `main`. Branch from it, named `<issue-number>-<short-description>`, e.g. `13-expectation-called-as-function`.
+Pull requests target `main`. Branch from it, named `<issue-number>-<short-description>`, e.g. `17-clj-files-not-scanned`.
 
-Title: `<prefix>(<scope>): <short description>`, one line.
+### Title
 
-Description:
+Same format as a commit title, one line:
+
+    <prefix>(<scope>): <short description>
+
+### Description
 
     Closes #<issue-number>
     ---
 
-    - First change
-    - Second change
+    - First change description
+    - Second change description
 
-One bullet per change. The issue carries the context.
+Keep bullets short; the issue carries the full context.
 
-## Merging
+### Changelog entry
 
-Rebase when every commit builds and passes on its own. Squash otherwise. No merge commits.
+A pull request with a user-facing change adds an entry under `## [Unreleased]` in [CHANGELOG.md](./CHANGELOG.md), in the same pull request, while the context is fresh. Describe the change as a user experiences it, the old symptom and the new behavior rather than the implementation, and end with the issue link. Internal refactors and test-only changes need no entry.
 
-A branch whose commits are "fix it", "address review", "typo" is one change.
+### Before opening one
 
-## Before opening a PR
+Run the local gate first; CI runs the same checks:
 
 ```bash
 bb fmt-check
@@ -60,16 +68,40 @@ Read the assertion count, not the exit code: a runner that discovers no namespac
 
 Regenerate with `bb gen-clr-rct` and commit the result.
 
-Projects that *use* rct-clr do the opposite and git-ignore theirs.
+## Merging
+
+Rebase when every commit builds and passes on its own. Squash otherwise. No merge commits.
+
+A branch whose commits are "fix it", "address review", "typo" is one change.
 
 ## Commits
 
-[Conventional Commits](https://www.conventionalcommits.org/), one-line title:
-
     <prefix>(<scope>): <description>
 
-Prefixes: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+| Prefix | Use for |
+|--------|---------|
+| `feat` | New features |
+| `fix` | Bug fixes |
+| `refactor` | Code restructuring, no behavior change |
+| `perf` | Performance improvement |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `build` | Build system or dependencies |
+| `ci` | CI configuration |
+| `style` | Formatting only |
+| `revert` | Reverts an earlier commit |
+| `chore` | Anything else that touches no source |
 
-The body is a few plain sentences: what changed, and the why a reader cannot get from the diff. Do not list the files touched, narrate the steps taken, or report test results; the diff and CI already show those. LLM-generated messages tend to include all three, so trim them before committing.
+- One line, under 100 characters.
+- Lowercase description, no trailing period.
+- Imperative mood: `add feature`, not `added feature`.
+- The scope is required and names the component: `gen`, `clr`, `deps`, `ci`, `repo`.
+- Details belong in the PR description, not the commit.
 
-Reference the issue with `Closes #42`. Issue numbers belong in commit messages and PR descriptions, never in source files or comments.
+Keep the body to a few plain sentences: the what and the non-obvious why. Do not list the files touched, narrate the steps taken, or report test results; the diff and CI already show those. LLM-generated messages tend to include all three, so trim them before committing.
+
+Reference the issue in the title or body, e.g. `(#42)` or `Closes #42`. Issue references belong in commit messages and PR descriptions only, never in source files or comments: trackers migrate, and in-code numbers go stale.
+
+## LLM context files
+
+LLM context files are not committed. The only exception could be `AGENTS.md`, and we still recommend against it.

--- a/README.md
+++ b/README.md
@@ -267,3 +267,8 @@ Example output (abbreviated):
             *1 nil, *2 nil, *3 nil, *e nil]
     (my-project-core-rct-block-0)))
 ```
+
+## Contributing
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) - issues, pull requests, the local gate, commits
+- [CHANGELOG.md](CHANGELOG.md) - what changed, per release

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Standard `^:rct/test` blocks work unchanged: the generator handles the platform 
 
 ^:rct/test
 (comment
-  (platform)
-  ;=> #?(:clj :jvm :cljr :clr)
+  (platform) ;=> #?(:clj :jvm :cljr :clr)
   )
 
 ;;;; Exception assertions with throws=>>
@@ -43,8 +42,9 @@ Standard `^:rct/test` blocks work unchanged: the generator handles the platform 
 ^:rct/test
 (comment
   (validate-positive! -1)
-  ;throws=>> {:error/message "must be positive"
-  ;;          :error/data {:value -1}}
+  ;throws=>>
+  {:error/message "must be positive"
+   :error/data {:value -1}}
   )
 
 ;;;; Reader conditionals in test expressions
@@ -59,8 +59,7 @@ Standard `^:rct/test` blocks work unchanged: the generator handles the platform 
 
 ^:rct/test
 (comment
-  (.Message (make-error "boom"))
-  ;=> "boom"
+  (.Message (make-error "boom")) ;=> "boom"
   )
 
 ;; -- examples_jvm/rct_clr/sample_jvm.cljc (RCT runner tests this) --
@@ -70,8 +69,7 @@ Standard `^:rct/test` blocks work unchanged: the generator handles the platform 
 
 ^:rct/test
 (comment
-  (.getMessage (make-error "boom"))
-  ;=> "boom"
+  (.getMessage (make-error "boom")) ;=> "boom"
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [`examples/`](examples/), [`examples_clr/`](examples_clr/), and [`examples_j
 
 ## How it works
 
-1. **Extract (JVM):** `rct-clr.gen` scans `.cljc` source files, loads each namespace, finds every `^:rct/test` block, and writes the assertions into a plain `.cljc` test file. (`.clj` files are ignored.)
+1. **Extract (JVM):** `rct-clr.gen` scans `.clj` and `.cljc` source files, loads each namespace, finds every `^:rct/test` block, and writes the assertions into a plain `.cljc` test file.
 2. **Test (CLR):** Run that file with `clojure.test` on MAGIC or ClojureCLR. It needs only `clojure.test` and `matcho.core`.
 
 ## Prerequisites

--- a/examples/rct_clr/sample.cljc
+++ b/examples/rct_clr/sample.cljc
@@ -139,6 +139,10 @@
   ;=> {::str/join :string-alias
   ;;   ::set/union :set-alias
   ;;   ::walk/walk :walk-alias}
+
+  ;; alias-qualified keyword in the test expression, not the expectation
+  (namespace ::str/join)
+  ;=> "clojure.string"
   )
 
 ;; --- Nested data structures ---

--- a/examples/rct_clr/sample.cljc
+++ b/examples/rct_clr/sample.cljc
@@ -14,24 +14,20 @@
 ^:rct/test
 (comment
   ;; => exact match
-  (add 1 2)
-  ;=> 3
+  (add 1 2) ;=> 3
 
-  (add -1 1)
-  ;=> 0
+  (add -1 1) ;=> 0
 
   ;; side-effect (nil expectation type) with literal
   (def base-val 10)
 
   ;; reference a prior def
-  (add base-val 5)
-  ;=> 15
+  (add base-val 5) ;=> 15
 
   ;; side-effect with computed value
   (def doubled (* base-val 2))
 
-  (add doubled 1)
-  ;=> 21
+  (add doubled 1) ;=> 21
   )
 
 ;; --- Seq-valued and symbol expectations ---
@@ -45,20 +41,16 @@
 ^:rct/test
 (comment
   ;; a keyword-headed list cannot be called, so it compares as data
-  (suits)
-  ;=> (:h :c :s :d)
+  (suits) ;=> (:h :c :s :d)
 
   ;; a number in head position
-  (map inc (range 3))
-  ;=> (1 2 3)
+  (map inc (range 3)) ;=> (1 2 3)
 
   ;; a symbol is compared, not resolved
-  (a-symbol)
-  ;=> foo
+  (a-symbol) ;=> foo
 
   ;; an expectation that evaluates keeps its value
-  (count (suits))
-  ;=> (+ 2 2)
+  (count (suits)) ;=> (+ 2 2)
   )
 
 ;; --- Chaining off *1 and *2 ---
@@ -68,16 +60,13 @@
 
 ^:rct/test
 (comment
-  (stack-push [1 2] 3)
-  ;=> [1 2 3]
+  (stack-push [1 2] 3) ;=> [1 2 3]
 
   ;; *1 carries the previous result
-  (count *1)
-  ;=> 3
+  (count *1) ;=> 3
 
   ;; *2 reaches one form further back
-  (peek *2)
-  ;=> 3
+  (peek *2) ;=> 3
   )
 
 ;; --- String operations and alias-qualified calls ---
@@ -87,20 +76,15 @@
 
 ^:rct/test
 (comment
-  (greet "World")
-  ;=> "Hello, World!"
+  (greet "World") ;=> "Hello, World!"
 
-  (str/upper-case (greet "test"))
-  ;=> "HELLO, TEST!"
+  (str/upper-case (greet "test")) ;=> "HELLO, TEST!"
 
-  (str/join ", " ["a" "b" "c"])
-  ;=> "a, b, c"
+  (str/join ", " ["a" "b" "c"]) ;=> "a, b, c"
 
-  (str/blank? "")
-  ;=> true
+  (str/blank? "") ;=> true
 
-  (str/blank? "x")
-  ;=> false
+  (str/blank? "x") ;=> false
   )
 
 ;; --- Platform via reader conditional ---
@@ -111,8 +95,7 @@
 ^:rct/test
 (comment
   ;; reader conditional in expectation
-  (platform)
-  ;=> #?(:clj :jvm :cljr :clr)
+  (platform) ;=> #?(:clj :jvm :cljr :clr)
   )
 
 ;; --- Namespace-qualified keywords ---
@@ -122,8 +105,7 @@
 
 ^:rct/test
 (comment
-  (my-type)
-  ;=> ::sample
+  (my-type) ;=> ::sample
   )
 
 ;; --- Alias-qualified keywords (multiple aliases) ---
@@ -136,13 +118,13 @@
 ^:rct/test
 (comment
   (alias-kws)
-  ;=> {::str/join :string-alias
-  ;;   ::set/union :set-alias
-  ;;   ::walk/walk :walk-alias}
+  ;=>
+  {::str/join :string-alias
+   ::set/union :set-alias
+   ::walk/walk :walk-alias}
 
   ;; alias-qualified keyword in the test expression, not the expectation
-  (namespace ::str/join)
-  ;=> "clojure.string"
+  (namespace ::str/join) ;=> "clojure.string"
   )
 
 ;; --- Nested data structures ---
@@ -157,14 +139,14 @@
 (comment
   ;; exact match on nested structure
   (user-profile 1 "Alice")
-  ;=> {:id 1
-  ;;   :name "Alice"
-  ;;   :settings {:theme "dark" :lang "en" :notifications true}
-  ;;   :tags #{:active :verified}}
+  ;=>
+  {:id 1
+   :name "Alice"
+   :settings {:theme "dark" :lang "en" :notifications true}
+   :tags #{:active :verified}}
 
   ;; nested access
-  (get-in (user-profile 1 "Alice") [:settings :theme])
-  ;=> "dark"
+  (get-in (user-profile 1 "Alice") [:settings :theme]) ;=> "dark"
   )
 
 ;; --- Pattern matching (=>>) with nested maps ---
@@ -179,13 +161,13 @@
 ^:rct/test
 (comment
   ;; =>> ignores extra keys at top level
-  (api-response {:users []})
-  ;=>> {:status 200 :body {:users []}}
+  (api-response {:users []}) ;=>> {:status 200 :body {:users []}}
 
   ;; =>> with nested pattern
   (api-response {:count 5})
-  ;=>> {:body {:count 5}
-  ;;    :timing {:start 0}}
+  ;=>>
+  {:body {:count 5}
+   :timing {:start 0}}
   )
 
 ;; --- =>> with collections ---
@@ -198,12 +180,10 @@
 ^:rct/test
 (comment
   ;; =>> with ellipsis on vector of maps
-  (scored-items)
-  ;=>> [{:name "a"} ...]
+  (scored-items) ;=>> [{:name "a"} ...]
 
   ;; =>> with ^:matcho/strict
-  (mapv :name (scored-items))
-  ;=>> ^:matcho/strict ["a" "b" "c"]
+  (mapv :name (scored-items)) ;=>> ^:matcho/strict ["a" "b" "c"]
   )
 
 ;; --- =>> with ellipsis on simple vectors ---
@@ -213,11 +193,9 @@
 
 ^:rct/test
 (comment
-  (fibonacci 7)
-  ;=>> [0 1 1 2 ...]
+  (fibonacci 7) ;=>> [0 1 1 2 ...]
 
-  (fibonacci 3)
-  ;=>> ^:matcho/strict [0 1 1]
+  (fibonacci 3) ;=>> ^:matcho/strict [0 1 1]
   )
 
 ;; --- Set operations (cross-platform library) ---
@@ -227,11 +205,9 @@
 
 ^:rct/test
 (comment
-  (common-tags #{:a :b :c} #{:b :c :d})
-  ;=> #{:b :c}
+  (common-tags #{:a :b :c} #{:b :c :d}) ;=> #{:b :c}
 
-  (set/union #{:a} #{:b})
-  ;=> #{:a :b}
+  (set/union #{:a} #{:b}) ;=> #{:a :b}
   )
 
 ;; --- Function composition ---
@@ -245,11 +221,9 @@
 
 ^:rct/test
 (comment
-  (normalize-name "  Alice BOB  ")
-  ;=> "alice bob"
+  (normalize-name "  Alice BOB  ") ;=> "alice bob"
 
-  (make-user "  Alice BOB  ")
-  ;=> {:name "alice bob" :slug "alice-bob"}
+  (make-user "  Alice BOB  ") ;=> {:name "alice bob" :slug "alice-bob"}
   )
 
 ;; --- Exception handling (throws=>>) ---
@@ -260,8 +234,7 @@
 
 ^:rct/test
 (comment
-  (validate-positive! -1)
-  ;throws=>> {:error/data {:value -1}}
+  (validate-positive! -1) ;throws=>> {:error/data {:value -1}}
   )
 
 (defn parse-config [m]
@@ -274,16 +247,14 @@
 ^:rct/test
 (comment
   ;; valid input passes through
-  (parse-config {:host "localhost"})
-  ;=> {:host "localhost"}
+  (parse-config {:host "localhost"}) ;=> {:host "localhost"}
 
   ;; not a map
   (parse-config "oops")
   ;throws=>> {:error/data {:got #?(:clj java.lang.String :cljr System.String)}}
 
   ;; missing key
-  (parse-config {:port 8080})
-  ;throws=>> {:error/data {:missing :host}}
+  (parse-config {:port 8080}) ;throws=>> {:error/data {:missing :host}}
   )
 
 ;; --- walk (cross-platform library, complex transformation) ---
@@ -298,8 +269,7 @@
 
 ^:rct/test
 (comment
-  (stringify-keys {:a 1 :b {:c 2}})
-  ;=> {"a" 1 "b" {"c" 2}}
+  (stringify-keys {:a 1 :b {:c 2}}) ;=> {"a" 1 "b" {"c" 2}}
   )
 
 ;; --- Boolean and nil edge cases ---
@@ -309,17 +279,13 @@
 
 ^:rct/test
 (comment
-  (truthy? 1)
-  ;=> true
+  (truthy? 1) ;=> true
 
-  (truthy? nil)
-  ;=> false
+  (truthy? nil) ;=> false
 
-  (truthy? false)
-  ;=> false
+  (truthy? false) ;=> false
 
-  (nil? nil)
-  ;=> true
+  (nil? nil) ;=> true
   )
 
 ;; --- Reader conditional in test expression ---
@@ -329,6 +295,5 @@
 
 ^:rct/test
 (comment
-  (ex-data (make-error "boom"))
-  ;=> {}
+  (ex-data (make-error "boom")) ;=> {}
   )

--- a/examples/rct_clr/sample_clj.clj
+++ b/examples/rct_clr/sample_clj.clj
@@ -1,0 +1,15 @@
+(ns rct-clr.sample-clj
+  "A .clj sample, scanned like a .cljc.
+  Portable code only, since the generated assertions run on the CLR.")
+
+(defn total [xs]
+  (reduce + 0 xs))
+
+^:rct/test
+(comment
+  (total [1 2 3])
+  ;=> 6
+
+  (total [])
+  ;=> 0
+  )

--- a/examples/rct_clr/sample_clj.clj
+++ b/examples/rct_clr/sample_clj.clj
@@ -8,6 +8,4 @@
 ^:rct/test
 (comment
   (total [1 2 3]) ;=> 6
-
-  (total []) ;=> 0
   )

--- a/examples/rct_clr/sample_clj.clj
+++ b/examples/rct_clr/sample_clj.clj
@@ -7,9 +7,7 @@
 
 ^:rct/test
 (comment
-  (total [1 2 3])
-  ;=> 6
+  (total [1 2 3]) ;=> 6
 
-  (total [])
-  ;=> 0
+  (total []) ;=> 0
   )

--- a/examples_clr/rct_clr/sample_clr.cljc
+++ b/examples_clr/rct_clr/sample_clr.cljc
@@ -10,16 +10,13 @@
 ^:rct/test
 (comment
   ;; CLR interop works without reader conditional in a CLR-only file
-  (.Message (make-error "boom"))
-  ;=> "boom"
+  (.Message (make-error "boom")) ;=> "boom"
 
   ;; reader conditional in test expression, interop method dispatch
-  #?(:cljr (.Message (make-error "boom")))
-  ;=> "boom"
+  #?(:cljr (.Message (make-error "boom"))) ;=> "boom"
 
   ;; simple reader conditional in test expression
-  #?(:clj :jvm :cljr :clr)
-  ;=> #?(:clj :jvm :cljr :clr)
+  #?(:clj :jvm :cljr :clr) ;=> #?(:clj :jvm :cljr :clr)
 
   ;; reader conditional nested inside a larger expression
   (str "error: " #?(:clj (.getMessage (make-error "boom")) :cljr (.Message (make-error "boom"))))

--- a/examples_jvm/rct_clr/sample_jvm.cljc
+++ b/examples_jvm/rct_clr/sample_jvm.cljc
@@ -9,10 +9,8 @@
 ^:rct/test
 (comment
   ;; JVM interop, mirrors the CLR test in sample_clr.cljc
-  (.getMessage (make-error "boom"))
-  ;=> "boom"
+  (.getMessage (make-error "boom")) ;=> "boom"
 
   ;; JVM interop nested inside a larger expression, mirrors CLR test
-  (str "error: " (.getMessage (make-error "boom")))
-  ;=> "error: boom"
+  (str "error: " (.getMessage (make-error "boom"))) ;=> "error: boom"
   )

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -41,7 +41,7 @@
         aliases (ns-aliases the-ns)]
     (into {:current ns-sym}
           (map (fn [[alias-sym ns-obj]]
-                 [(keyword alias-sym) (ns-name ns-obj)]))
+                 [alias-sym (ns-name ns-obj)]))
           aliases)))
 
 ^:rct/test
@@ -49,16 +49,16 @@
   (build-resolver 'rct-clr.gen)
   ;=>
   {:current 'rct-clr.gen
-   :cli 'clojure.tools.cli
-   :emit 'com.mjdowney.rich-comment-tests.emit-tests
-   :io 'clojure.java.io
-   :ns-file 'clojure.tools.namespace.file
-   :ns-parse 'clojure.tools.namespace.parse
-   :rct 'com.mjdowney.rich-comment-tests
-   :string 'clojure.string
-   :tr 'clojure.tools.reader
-   :walk 'clojure.walk
-   :z 'rewrite-clj.zip}
+   'cli 'clojure.tools.cli
+   'emit 'com.mjdowney.rich-comment-tests.emit-tests
+   'io 'clojure.java.io
+   'ns-file 'clojure.tools.namespace.file
+   'ns-parse 'clojure.tools.namespace.parse
+   'rct 'com.mjdowney.rich-comment-tests
+   'string 'clojure.string
+   'tr 'clojure.tools.reader
+   'walk 'clojure.walk
+   'z 'rewrite-clj.zip}
 
   ;; namespace with no aliases returns just :current
   (def rct-test-bare-ns (create-ns (gensym "bare-ns-")))

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -12,12 +12,20 @@
             [clojure.walk :as walk]
             [rewrite-clj.zip :as z]))
 
-(defn find-cljc-files
-  "Find all .cljc files in dir. Ignores .clj, since CLR can only run .cljc."
+(defn- cljc?
+  [file]
+  (string/ends-with? (.getName file) ".cljc"))
+
+(defn find-source-files
+  "Find all .clj and .cljc files in dir, keeping the .cljc when a namespace is
+  present as both."
   [dir]
   (->> (io/file dir)
        file-seq
-       (filter #(and (.isFile %) (string/ends-with? (.getName %) ".cljc")))
+       (filter #(and (.isFile %) (re-find #"\.cljc?$" (.getName %))))
+       (group-by #(string/replace (.getPath %) #"\.cljc?$" ""))
+       vals
+       (map #(or (first (filter cljc? %)) (first %)))
        sort))
 
 (defn file->ns-sym
@@ -520,7 +528,7 @@
   Throws ex-info if a namespace fails to load."
   [{:keys [src-dirs output namespace]}]
   (let [output-ns (symbol namespace)
-        files (mapcat find-cljc-files src-dirs)
+        files (mapcat find-source-files src-dirs)
         file-blocks (for [f files
                           :let [ns-sym (file->ns-sym f)]
                           :when (if ns-sym

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -107,21 +107,22 @@
          (catch (read-string "#?(:clj Exception :cljr System.Exception)") e
            (read-string "#?(:clj (.getMessage e) :cljr (.Message e))")))
    'rct-clr.gen)
-  ;=> '(try (foo)
-  ;;        (catch System.Exception e
-  ;;          (.Message e)))
+  ;=>
+  '(try (foo)
+        (catch System.Exception e
+          (.Message e)))
 
   ;; resolves reader conditional nested inside a regular expression
   (resolve-reader-conditionals
    '(+ (/ pos-score visits)
        (read-string "#?(:clj (Math/sqrt visits) :cljr (Math/Sqrt visits))"))
    'rct-clr.gen)
-  ;=> '(+ (/ pos-score visits)
-  ;;       (Math/Sqrt visits))
+  ;=>
+  '(+ (/ pos-score visits)
+      (Math/Sqrt visits))
 
   ;; passes through forms without reader conditionals unchanged
-  (resolve-reader-conditionals '(+ 1 2) 'rct-clr.gen)
-  ;=> '(+ 1 2)
+  (resolve-reader-conditionals '(+ 1 2) 'rct-clr.gen) ;=> '(+ 1 2)
 
   ;; resolves #? inside a tagged literal
   (resolve-reader-conditionals
@@ -173,26 +174,20 @@
 
 ^:rct/test
 (comment
-  (self-evaluating? 42)
-  ;=> true
+  (self-evaluating? 42) ;=> true
 
   ;; a seq evaluates as a call
-  (self-evaluating? '(:h :c :s))
-  ;=> false
+  (self-evaluating? '(:h :c :s)) ;=> false
 
   ;; a symbol evaluates as a var reference
-  (self-evaluating? 'foo)
-  ;=> false
+  (self-evaluating? 'foo) ;=> false
 
-  (self-evaluating? [1 2 3])
-  ;=> true
+  (self-evaluating? [1 2 3]) ;=> true
 
   ;; a collection is only as safe as its elements, map entries included
-  (self-evaluating? '{:a (1 2)})
-  ;=> false
+  (self-evaluating? '{:a (1 2)}) ;=> false
 
-  (self-evaluating? [])
-  ;=> true
+  (self-evaluating? []) ;=> true
   )
 
 (defn read-expectation
@@ -370,11 +365,9 @@
 
 ^:rct/test
 (comment
-  (ns-sym->test-base 'my.cool.namespace)
-  ;=> "my-cool-namespace"
+  (ns-sym->test-base 'my.cool.namespace) ;=> "my-cool-namespace"
 
-  (ns-sym->test-base 'single)
-  ;=> "single"
+  (ns-sym->test-base 'single) ;=> "single"
   )
 
 (defn write-block-fn
@@ -515,11 +508,9 @@
   ;=> {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]}
 
   ;; unknown flag produces errors
-  (contains? (validate-opts ["--bogus"]) :errors)
-  ;=> true
+  (contains? (validate-opts ["--bogus"]) :errors) ;=> true
 
-  (contains? (validate-opts ["-h"]) :help)
-  ;=> true
+  (contains? (validate-opts ["-h"]) :help) ;=> true
   )
 
 (defn generate

--- a/src/rct_clr/gen.cljc
+++ b/src/rct_clr/gen.cljc
@@ -112,15 +112,6 @@
         (catch System.Exception e
           (.Message e)))
 
-  ;; resolves reader conditional nested inside a regular expression
-  (resolve-reader-conditionals
-   '(+ (/ pos-score visits)
-       (read-string "#?(:clj (Math/sqrt visits) :cljr (Math/Sqrt visits))"))
-   'rct-clr.gen)
-  ;=>
-  '(+ (/ pos-score visits)
-      (Math/Sqrt visits))
-
   ;; passes through forms without reader conditionals unchanged
   (resolve-reader-conditionals '(+ 1 2) 'rct-clr.gen) ;=> '(+ 1 2)
 
@@ -186,8 +177,6 @@
 
   ;; a collection is only as safe as its elements, map entries included
   (self-evaluating? '{:a (1 2)}) ;=> false
-
-  (self-evaluating? []) ;=> true
   )
 
 (defn read-expectation
@@ -319,14 +308,6 @@
                'test-output-ns)
   ;=> '(matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))
 
-  ;; =>> with ellipsis elision
-  (datum->form {:test-sexpr '(range 5)
-                :expectation-string "[0 1 ...]"
-                :expectation-type '=>>}
-               'rct-clr.gen
-               'test-output-ns)
-  ;=> '(matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))
-
   ;; throws=>>: try/catch, binds *e, qualified error->map
   (datum->form {:test-sexpr '(boom!)
                 :expectation-string "{:error/class Exception}"
@@ -339,24 +320,7 @@
         (catch System.Exception e
           (set! *e e)
           (matcho.core/assert {:error/class Exception}
-                              (test-output-ns/error->map e))))
-
-  ;; => with reader conditional: read-expectation resolves to CLR branch
-  (datum->form {:test-sexpr '(get-platform)
-                :expectation-string "#?(:clj :jvm :cljr :clr)"
-                :expectation-type '=>}
-               'rct-clr.gen
-               'test-output-ns)
-  ;=> '(clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))
-
-  ;; => with namespace-qualified keyword in expectation
-  (datum->form {:test-sexpr '(get-type)
-                :expectation-string "::foo"
-                :expectation-type '=>}
-               'rct-clr.gen
-               'test-output-ns)
-  ;=> '(clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))
-  )
+                              (test-output-ns/error->map e)))))
 
 (defn ns-sym->test-base
   "Convert namespace symbol to base name for tests."
@@ -366,8 +330,6 @@
 ^:rct/test
 (comment
   (ns-sym->test-base 'my.cool.namespace) ;=> "my-cool-namespace"
-
-  (ns-sym->test-base 'single) ;=> "single"
   )
 
 (defn write-block-fn

--- a/test/rct_clr/gen_test.clj
+++ b/test/rct_clr/gen_test.clj
@@ -57,7 +57,7 @@
 
 (defn- rct-source
   "Minimal .cljc source with ^:rct/test blocks exercising the given assertion types.
-  assertion-types is a vector of :=>, :=>>, and/or :throws=>>.
+  assertion-types is a vector of :=> and/or :=>>.
   blocks controls how many ^:rct/test blocks to produce (default 1)."
   ([ns-sym assertion-types] (rct-source ns-sym assertion-types 1))
   ([ns-sym assertion-types blocks]
@@ -67,9 +67,7 @@
                     :=> {:defn (str "(defn fn-" i " [] " (inc i) ")")
                          :test (str "  (fn-" i ")\n  ;=> " (inc i))}
                     :=>> {:defn (str "(defn fn-" i " [] {:result " (inc i) " :extra 99})")
-                          :test (str "  (fn-" i ")\n  ;=>> {:result " (inc i) "}")}
-                    :throws=>> {:defn (str "(defn fn-" i " [] (throw (ex-info \"boom\" {:code 42})))")
-                                :test (str "  (fn-" i ")\n  ;throws=>> {:error/class clojure.lang.ExceptionInfo}")}))
+                          :test (str "  (fn-" i ")\n  ;=>> {:result " (inc i) "}")}))
                 assertion-types)
          block-groups (partition-all (max 1 (Math/ceil (/ (count parts) blocks))) parts)]
      (str "(ns " ns-sym ")\n"
@@ -145,11 +143,7 @@
         required-libs (mapv first (rest require-form))]
     (testing "source namespaces appear sorted in requires"
       (let [source-libs (filterv #{'aa.first 'mm.middle 'zz.last} required-libs)]
-        (is (= ['aa.first 'mm.middle 'zz.last] source-libs))))
-    (testing "always includes clojure.test and matcho.core"
-      (let [lib-set (set required-libs)]
-        (is (contains? lib-set 'clojure.test))
-        (is (contains? lib-set 'matcho.core))))))
+        (is (= ['aa.first 'mm.middle 'zz.last] source-libs))))))
 
 ;; ---------------------------------------------------------------------------
 ;; write-deftest
@@ -180,16 +174,6 @@
                      :expectation-string "3"
                      :expectation-type '=>
                      :location [9 1]}
-                    ;; =>> with location
-                    {:test-sexpr '(get-status)
-                     :expectation-string "{:status 200}"
-                     :expectation-type '=>>
-                     :location [11 1]}
-                    ;; throws=>> with location
-                    {:test-sexpr '(kaboom)
-                     :expectation-string "{:error/class Exception}"
-                     :expectation-type 'throws=>>
-                     :location [13 1]}
                     ;; assertion without location
                     {:test-sexpr '(+ 3 4)
                      :expectation-string "7"
@@ -197,10 +181,10 @@
         out (write-block-output block-data)
         [defn-form :as forms] (read-all-forms out)
         body (vec (drop 3 defn-form))]
-    (testing "single defn- form with all six body forms"
+    (testing "single defn- form with all four body forms"
       (is (= 1 (count forms)))
       (is (= 'defn- (first defn-form)))
-      (is (= 6 (count body))))
+      (is (= 4 (count body))))
     (testing "side-effect with location is bare eval, not testing"
       (is (= 'eval (first (nth body 0)))))
     (testing "side-effect without location is bare eval"
@@ -208,16 +192,11 @@
     (testing "=> with location wrapped in testing"
       (is (= 'testing (first (nth body 2))))
       (is (= "example.cljc:9" (second (nth body 2)))))
-    (testing "=>> with location wrapped in testing"
-      (is (= 'testing (first (nth body 3)))))
-    (testing "throws=>> with location wrapped in testing"
-      (is (= 'testing (first (nth body 4)))))
     (testing "assertion without location is bare eval"
-      (is (= 'eval (first (nth body 5)))))
+      (is (= 'eval (first (nth body 3)))))
     (testing "location comments for datums with locations"
       (is (string/includes? out ";; example.cljc:5"))
-      (is (string/includes? out ";; example.cljc:9"))
-      (is (string/includes? out ";; example.cljc:13")))
+      (is (string/includes? out ";; example.cljc:9")))
     (testing "no location comments for datums without locations"
       (is (not (re-find #";;.*def y" out)))
       (is (not (re-find #";;.*\+ 3 4" out))))))
@@ -257,10 +236,6 @@
     (testing "keeps the .cljc when a namespace is present as both"
       (is (= ["both.cljc"]
              (mapv #(.getName %) (gen/find-source-files (str dir))))))))
-
-(deftest find-source-files-empty-dir-test
-  (with-tmp-dir [dir {}]
-    (is (empty? (gen/find-source-files (str dir))))))
 
 (deftest find-source-files-nested-test
   (with-tmp-dir [dir {"top.cljc"       "(ns top)"
@@ -419,23 +394,6 @@
       (testing "skips the no-ns file, processes the good one"
         (is (= {:namespaces 1 :blocks 1} result))
         (is (not (string/includes? (slurp (:output project)) "stray")))))))
-
-(deftest generate-throws-assertion-test
-  (with-gen-project [project {:files {"src/throws_ns/err.cljc"
-                                      (rct-source 'throws-ns.err [:throws=>>])}
-                              :src-dirs ["src"]}]
-    (let [result (gen/generate {:src-dirs (:src-dirs project)
-                                :output (:output project)
-                                :namespace "test.throws"})
-          content (slurp (:output project))
-          forms (read-all-forms content)]
-      (testing "discovers the namespace and block"
-        (is (= {:namespaces 1 :blocks 1} result)))
-      (testing "generated output contains try/catch structure"
-        (let [all-syms (set (filter symbol? (tree-seq coll? seq forms)))]
-          (is (contains? all-syms 'try))
-          (is (contains? all-syms 'catch))
-          (is (contains? all-syms 'matcho.core/assert)))))))
 
 (deftest generate-multi-block-per-file-test
   (with-gen-project [project {:files {"src/mb/multi.cljc" (rct-source 'mb.multi [:=> :=>>] 2)}

--- a/test/rct_clr/gen_test.clj
+++ b/test/rct_clr/gen_test.clj
@@ -239,30 +239,38 @@
     (is (= expected out))))
 
 ;; ---------------------------------------------------------------------------
-;; find-cljc-files
+;; find-source-files
 ;; ---------------------------------------------------------------------------
 
-(deftest find-cljc-files-test
-  (with-tmp-dir [dir {"foo.cljc" "(ns foo)"
-                      "bar.clj"  "(ns bar)"
-                      "baz.txt"  "hello"}]
-    (testing "finds only .cljc files"
-      (is (= ["foo.cljc"] (mapv #(.getName %) (gen/find-cljc-files (str dir))))))))
+(deftest find-source-files-test
+  (with-tmp-dir [dir {"foo.cljc"  "(ns foo)"
+                      "bar.clj"   "(ns bar)"
+                      "quux.cljs" "(ns quux)"
+                      "baz.txt"   "hello"}]
+    (testing "finds .clj and .cljc files"
+      (is (= ["bar.clj" "foo.cljc"]
+             (mapv #(.getName %) (gen/find-source-files (str dir))))))))
 
-(deftest find-cljc-files-empty-dir-test
+(deftest find-source-files-both-extensions-test
+  (with-tmp-dir [dir {"both.cljc" "(ns both)"
+                      "both.clj"  "(ns both)"}]
+    (testing "keeps the .cljc when a namespace is present as both"
+      (is (= ["both.cljc"]
+             (mapv #(.getName %) (gen/find-source-files (str dir))))))))
+
+(deftest find-source-files-empty-dir-test
   (with-tmp-dir [dir {}]
-    (is (empty? (gen/find-cljc-files (str dir))))))
+    (is (empty? (gen/find-source-files (str dir))))))
 
-(deftest find-cljc-files-nested-test
-  (with-tmp-dir [dir {"top.cljc"        "(ns top)"
-                      "sub/nested.cljc" "(ns sub.nested)"
-                      "sub/ignored.clj" "(ns sub.ignored)"}]
-    (let [names (mapv #(.getName %) (gen/find-cljc-files (str dir)))]
-      (testing "finds .cljc in subdirectories, sorted"
-        (is (= ["nested.cljc" "top.cljc"] names))))))
+(deftest find-source-files-nested-test
+  (with-tmp-dir [dir {"top.cljc"       "(ns top)"
+                      "sub/nested.clj" "(ns sub.nested)"}]
+    (let [names (mapv #(.getName %) (gen/find-source-files (str dir)))]
+      (testing "finds files in subdirectories, sorted"
+        (is (= ["nested.clj" "top.cljc"] names))))))
 
-(deftest find-cljc-files-nonexistent-dir-test
-  (is (empty? (gen/find-cljc-files "/tmp/rct-clr-does-not-exist-999"))))
+(deftest find-source-files-nonexistent-dir-test
+  (is (empty? (gen/find-source-files "/tmp/rct-clr-does-not-exist-999"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Self-referential integration: file->ns-sym, file->rct-blocks

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -35,86 +35,74 @@
   ;; gen.cljc:105
   (testing "gen.cljc:105" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen))))))))
   ;; gen.cljc:116
-  (testing "gen.cljc:116" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
+  (testing "gen.cljc:116" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
+  ;; gen.cljc:119
+  (testing "gen.cljc:119" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
   ;; gen.cljc:125
-  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
-  ;; gen.cljc:128
-  (testing "gen.cljc:128" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
-  ;; gen.cljc:134
-  (testing "gen.cljc:134" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
-  ;; gen.cljc:138
-  (testing "gen.cljc:138" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
-  ;; gen.cljc:144
-  (testing "gen.cljc:144" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
+  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
+  ;; gen.cljc:129
+  (testing "gen.cljc:129" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
+  ;; gen.cljc:135
+  (testing "gen.cljc:135" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
 (defn- rct-clr-gen-rct-block-2 []
-  ;; gen.cljc:177
-  (testing "gen.cljc:177" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
-  ;; gen.cljc:180
-  (testing "gen.cljc:180" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
-  ;; gen.cljc:183
-  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
-  ;; gen.cljc:185
-  (testing "gen.cljc:185" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
-  ;; gen.cljc:188
-  (testing "gen.cljc:188" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
-  ;; gen.cljc:190
-  (testing "gen.cljc:190" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
+  ;; gen.cljc:168
+  (testing "gen.cljc:168" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
+  ;; gen.cljc:171
+  (testing "gen.cljc:171" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
+  ;; gen.cljc:174
+  (testing "gen.cljc:174" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
+  ;; gen.cljc:176
+  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
+  ;; gen.cljc:179
+  (testing "gen.cljc:179" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)})))))))))
 (defn- rct-clr-gen-rct-block-3 []
-  ;; gen.cljc:211
-  (testing "gen.cljc:211" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:200
+  (testing "gen.cljc:200" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:205
+  (testing "gen.cljc:205" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:210
+  (testing "gen.cljc:210" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
   ;; gen.cljc:216
-  (testing "gen.cljc:216" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:221
-  (testing "gen.cljc:221" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
-  ;; gen.cljc:227
-  (testing "gen.cljc:227" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:233
-  (testing "gen.cljc:233" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:239
-  (testing "gen.cljc:239" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:245
-  (testing "gen.cljc:245" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:251
-  (testing "gen.cljc:251" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
-  ;; gen.cljc:257
-  (testing "gen.cljc:257" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
+  (testing "gen.cljc:216" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:222
+  (testing "gen.cljc:222" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:228
+  (testing "gen.cljc:228" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:234
+  (testing "gen.cljc:234" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:240
+  (testing "gen.cljc:240" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
+  ;; gen.cljc:246
+  (testing "gen.cljc:246" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
 (defn- rct-clr-gen-rct-block-4 []
-  ;; gen.cljc:292
-  (testing "gen.cljc:292" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:299
-  (testing "gen.cljc:299" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:307
-  (testing "gen.cljc:307" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:315
-  (testing "gen.cljc:315" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:323
-  (testing "gen.cljc:323" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:331
-  (testing "gen.cljc:331" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:345
-  (testing "gen.cljc:345" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:353
-  (testing "gen.cljc:353" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
+  ;; gen.cljc:281
+  (testing "gen.cljc:281" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:288
+  (testing "gen.cljc:288" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:296
+  (testing "gen.cljc:296" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:304
+  (testing "gen.cljc:304" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:312
+  (testing "gen.cljc:312" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns)))))))))
 (defn- rct-clr-gen-rct-block-5 []
-  ;; gen.cljc:368
-  (testing "gen.cljc:368" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
-  ;; gen.cljc:370
-  (testing "gen.cljc:370" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
+  ;; gen.cljc:332
+  (testing "gen.cljc:332" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace)))))))))
 (defn- rct-clr-gen-rct-block-6 []
-  ;; gen.cljc:491
-  (testing "gen.cljc:491" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
-  ;; gen.cljc:495
-  (testing "gen.cljc:495" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
-  ;; gen.cljc:499
-  (testing "gen.cljc:499" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
-  ;; gen.cljc:503
-  (testing "gen.cljc:503" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
-  ;; gen.cljc:507
-  (testing "gen.cljc:507" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
-  ;; gen.cljc:511
-  (testing "gen.cljc:511" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
-  ;; gen.cljc:513
-  (testing "gen.cljc:513" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
+  ;; gen.cljc:453
+  (testing "gen.cljc:453" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:457
+  (testing "gen.cljc:457" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:461
+  (testing "gen.cljc:461" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
+  ;; gen.cljc:465
+  (testing "gen.cljc:465" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
+  ;; gen.cljc:469
+  (testing "gen.cljc:469" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
+  ;; gen.cljc:473
+  (testing "gen.cljc:473" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
+  ;; gen.cljc:475
+  (testing "gen.cljc:475" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
 (deftest rct-clr-gen-rct
   (binding [*ns* (the-ns 'rct-clr.gen)
             *1 nil, *2 nil, *3 nil, *e nil]

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -24,7 +24,7 @@
 ;; rct-clr.gen
 (defn- rct-clr-gen-rct-block-0 []
   ;; gen.cljc:49
-  (testing "gen.cljc:49" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (rct-clr.rct-generated-test/bind-repl-vars! (build-resolver (quote rct-clr.gen))))))))
+  (testing "gen.cljc:49" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {(quote ns-parse) (quote clojure.tools.namespace.parse), (quote cli) (quote clojure.tools.cli), (quote string) (quote clojure.string), (quote walk) (quote clojure.walk), (quote tr) (quote clojure.tools.reader), :current (quote rct-clr.gen), (quote emit) (quote com.mjdowney.rich-comment-tests.emit-tests), (quote ns-file) (quote clojure.tools.namespace.file), (quote io) (quote clojure.java.io), (quote rct) (quote com.mjdowney.rich-comment-tests), (quote z) (quote rewrite-clj.zip)})) (rct-clr.rct-generated-test/bind-repl-vars! (build-resolver (quote rct-clr.gen))))))))
   ;; gen.cljc:64
   (eval (quote (rct-clr.rct-generated-test/bind-repl-vars! (def rct-test-bare-ns (create-ns (gensym "bare-ns-"))))))
   ;; gen.cljc:65

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -23,98 +23,98 @@
 
 ;; rct-clr.gen
 (defn- rct-clr-gen-rct-block-0 []
-  ;; gen.cljc:41
-  (testing "gen.cljc:41" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (rct-clr.rct-generated-test/bind-repl-vars! (build-resolver (quote rct-clr.gen))))))))
-  ;; gen.cljc:56
+  ;; gen.cljc:49
+  (testing "gen.cljc:49" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:io (quote clojure.java.io), :walk (quote clojure.walk), :tr (quote clojure.tools.reader), :ns-file (quote clojure.tools.namespace.file), :string (quote clojure.string), :z (quote rewrite-clj.zip), :ns-parse (quote clojure.tools.namespace.parse), :rct (quote com.mjdowney.rich-comment-tests), :current (quote rct-clr.gen), :emit (quote com.mjdowney.rich-comment-tests.emit-tests), :cli (quote clojure.tools.cli)})) (rct-clr.rct-generated-test/bind-repl-vars! (build-resolver (quote rct-clr.gen))))))))
+  ;; gen.cljc:64
   (eval (quote (rct-clr.rct-generated-test/bind-repl-vars! (def rct-test-bare-ns (create-ns (gensym "bare-ns-"))))))
-  ;; gen.cljc:57
-  (testing "gen.cljc:57" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:current (ns-name rct-test-bare-ns)})) (rct-clr.rct-generated-test/bind-repl-vars! (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result))))))))
+  ;; gen.cljc:65
+  (testing "gen.cljc:65" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote {:current (ns-name rct-test-bare-ns)})) (rct-clr.rct-generated-test/bind-repl-vars! (let [result (build-resolver (ns-name rct-test-bare-ns))] (remove-ns (ns-name rct-test-bare-ns)) result))))))))
 (defn- rct-clr-gen-rct-block-1 []
-  ;; gen.cljc:91
-  (testing "gen.cljc:91" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen))))))))
-  ;; gen.cljc:97
-  (testing "gen.cljc:97" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen))))))))
-  ;; gen.cljc:107
-  (testing "gen.cljc:107" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
+  ;; gen.cljc:99
+  (testing "gen.cljc:99" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen))))))))
+  ;; gen.cljc:105
+  (testing "gen.cljc:105" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen))))))))
   ;; gen.cljc:115
-  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
-  ;; gen.cljc:119
-  (testing "gen.cljc:119" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
-  ;; gen.cljc:125
-  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
-  ;; gen.cljc:129
-  (testing "gen.cljc:129" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
-  ;; gen.cljc:135
-  (testing "gen.cljc:135" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
+  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
+  ;; gen.cljc:123
+  (testing "gen.cljc:123" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
+  ;; gen.cljc:127
+  (testing "gen.cljc:127" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
+  ;; gen.cljc:133
+  (testing "gen.cljc:133" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
+  ;; gen.cljc:137
+  (testing "gen.cljc:137" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
+  ;; gen.cljc:143
+  (testing "gen.cljc:143" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
 (defn- rct-clr-gen-rct-block-2 []
-  ;; gen.cljc:168
-  (testing "gen.cljc:168" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
-  ;; gen.cljc:172
-  (testing "gen.cljc:172" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
   ;; gen.cljc:176
-  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
-  ;; gen.cljc:179
-  (testing "gen.cljc:179" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
-  ;; gen.cljc:183
-  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
-  ;; gen.cljc:186
-  (testing "gen.cljc:186" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
+  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
+  ;; gen.cljc:180
+  (testing "gen.cljc:180" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
+  ;; gen.cljc:184
+  (testing "gen.cljc:184" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
+  ;; gen.cljc:187
+  (testing "gen.cljc:187" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
+  ;; gen.cljc:191
+  (testing "gen.cljc:191" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
+  ;; gen.cljc:194
+  (testing "gen.cljc:194" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
 (defn- rct-clr-gen-rct-block-3 []
-  ;; gen.cljc:208
-  (testing "gen.cljc:208" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:213
-  (testing "gen.cljc:213" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:218
-  (testing "gen.cljc:218" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
-  ;; gen.cljc:224
-  (testing "gen.cljc:224" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:230
-  (testing "gen.cljc:230" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:236
-  (testing "gen.cljc:236" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:242
-  (testing "gen.cljc:242" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:248
-  (testing "gen.cljc:248" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
-  ;; gen.cljc:254
-  (testing "gen.cljc:254" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
+  ;; gen.cljc:216
+  (testing "gen.cljc:216" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:221
+  (testing "gen.cljc:221" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:226
+  (testing "gen.cljc:226" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
+  ;; gen.cljc:232
+  (testing "gen.cljc:232" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:238
+  (testing "gen.cljc:238" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:244
+  (testing "gen.cljc:244" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:250
+  (testing "gen.cljc:250" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:256
+  (testing "gen.cljc:256" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
+  ;; gen.cljc:262
+  (testing "gen.cljc:262" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
 (defn- rct-clr-gen-rct-block-4 []
-  ;; gen.cljc:289
-  (testing "gen.cljc:289" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:296
-  (testing "gen.cljc:296" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:297
+  (testing "gen.cljc:297" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
   ;; gen.cljc:304
-  (testing "gen.cljc:304" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  (testing "gen.cljc:304" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
   ;; gen.cljc:312
-  (testing "gen.cljc:312" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  (testing "gen.cljc:312" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
   ;; gen.cljc:320
-  (testing "gen.cljc:320" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  (testing "gen.cljc:320" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
   ;; gen.cljc:328
-  (testing "gen.cljc:328" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:342
-  (testing "gen.cljc:342" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  (testing "gen.cljc:328" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:336
+  (testing "gen.cljc:336" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
   ;; gen.cljc:350
-  (testing "gen.cljc:350" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
+  (testing "gen.cljc:350" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:358
+  (testing "gen.cljc:358" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
 (defn- rct-clr-gen-rct-block-5 []
-  ;; gen.cljc:365
-  (testing "gen.cljc:365" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
-  ;; gen.cljc:368
-  (testing "gen.cljc:368" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
+  ;; gen.cljc:373
+  (testing "gen.cljc:373" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
+  ;; gen.cljc:376
+  (testing "gen.cljc:376" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
 (defn- rct-clr-gen-rct-block-6 []
-  ;; gen.cljc:490
-  (testing "gen.cljc:490" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
-  ;; gen.cljc:494
-  (testing "gen.cljc:494" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
   ;; gen.cljc:498
-  (testing "gen.cljc:498" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
+  (testing "gen.cljc:498" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
   ;; gen.cljc:502
-  (testing "gen.cljc:502" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
+  (testing "gen.cljc:502" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
   ;; gen.cljc:506
-  (testing "gen.cljc:506" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
+  (testing "gen.cljc:506" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
   ;; gen.cljc:510
-  (testing "gen.cljc:510" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
-  ;; gen.cljc:513
-  (testing "gen.cljc:513" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
+  (testing "gen.cljc:510" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
+  ;; gen.cljc:514
+  (testing "gen.cljc:514" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
+  ;; gen.cljc:518
+  (testing "gen.cljc:518" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
+  ;; gen.cljc:521
+  (testing "gen.cljc:521" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
 (deftest rct-clr-gen-rct
   (binding [*ns* (the-ns 'rct-clr.gen)
             *1 nil, *2 nil, *3 nil, *e nil]

--- a/test/rct_clr/rct_generated_test.cljc
+++ b/test/rct_clr/rct_generated_test.cljc
@@ -34,87 +34,87 @@
   (testing "gen.cljc:99" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (.Message e)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (.Message e)) (quote rct-clr.gen))))))))
   ;; gen.cljc:105
   (testing "gen.cljc:105" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (foo) (catch System.Exception e (.Message e)))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (try (foo) (catch System.Exception e (.Message e)))) (quote rct-clr.gen))))))))
-  ;; gen.cljc:115
-  (testing "gen.cljc:115" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
-  ;; gen.cljc:123
-  (testing "gen.cljc:123" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
-  ;; gen.cljc:127
-  (testing "gen.cljc:127" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
-  ;; gen.cljc:133
-  (testing "gen.cljc:133" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
-  ;; gen.cljc:137
-  (testing "gen.cljc:137" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
-  ;; gen.cljc:143
-  (testing "gen.cljc:143" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
+  ;; gen.cljc:116
+  (testing "gen.cljc:116" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ (/ pos-score visits) (Math/Sqrt visits))))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ (/ pos-score visits) (Math/Sqrt visits))) (quote rct-clr.gen))))))))
+  ;; gen.cljc:125
+  (testing "gen.cljc:125" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (+ 1 2)) (quote rct-clr.gen))))))))
+  ;; gen.cljc:128
+  (testing "gen.cljc:128" (eval (quote (clojure.test/is (= #inst "2025-01-01T00:00:00.000-00:00" (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote #inst "2025-01-01T00:00:00.000-00:00") (quote rct-clr.gen))))))))
+  ;; gen.cljc:134
+  (testing "gen.cljc:134" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (read-string "[1 2 3]")))) (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote (read-string "[1 2 3]")) (quote rct-clr.gen))))))))
+  ;; gen.cljc:138
+  (testing "gen.cljc:138" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote nil) (quote rct-clr.gen))))))))
+  ;; gen.cljc:144
+  (testing "gen.cljc:144" (eval (quote (clojure.test/is (= :fallback (rct-clr.rct-generated-test/bind-repl-vars! (resolve-reader-conditionals (quote :fallback) (quote rct-clr.gen)))))))))
 (defn- rct-clr-gen-rct-block-2 []
-  ;; gen.cljc:176
-  (testing "gen.cljc:176" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
+  ;; gen.cljc:177
+  (testing "gen.cljc:177" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? 42)))))))
   ;; gen.cljc:180
   (testing "gen.cljc:180" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote (:h :c :s)))))))))
-  ;; gen.cljc:184
-  (testing "gen.cljc:184" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
-  ;; gen.cljc:187
-  (testing "gen.cljc:187" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
-  ;; gen.cljc:191
-  (testing "gen.cljc:191" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
-  ;; gen.cljc:194
-  (testing "gen.cljc:194" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
+  ;; gen.cljc:183
+  (testing "gen.cljc:183" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote foo))))))))
+  ;; gen.cljc:185
+  (testing "gen.cljc:185" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? [1 2 3])))))))
+  ;; gen.cljc:188
+  (testing "gen.cljc:188" (eval (quote (clojure.test/is (= false (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? (quote {:a (1 2)}))))))))
+  ;; gen.cljc:190
+  (testing "gen.cljc:190" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (self-evaluating? []))))))))
 (defn- rct-clr-gen-rct-block-3 []
+  ;; gen.cljc:211
+  (testing "gen.cljc:211" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
   ;; gen.cljc:216
-  (testing "gen.cljc:216" (eval (quote (clojure.test/is (= 42 (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "42"} (quote rct-clr.gen))))))))
+  (testing "gen.cljc:216" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
   ;; gen.cljc:221
-  (testing "gen.cljc:221" (eval (quote (clojure.test/is (= [1 2] (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:226
-  (testing "gen.cljc:226" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
-  ;; gen.cljc:232
-  (testing "gen.cljc:232" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:238
-  (testing "gen.cljc:238" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:244
-  (testing "gen.cljc:244" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:250
-  (testing "gen.cljc:250" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
-  ;; gen.cljc:256
-  (testing "gen.cljc:256" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
-  ;; gen.cljc:262
-  (testing "gen.cljc:262" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
+  (testing "gen.cljc:221" (eval (quote (clojure.test/is (= nil (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string nil} (quote rct-clr.gen))))))))
+  ;; gen.cljc:227
+  (testing "gen.cljc:227" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (+ 1 2)))) (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "(+ 1 2)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:233
+  (testing "gen.cljc:233" (eval (quote (clojure.test/is (= :clr (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:239
+  (testing "gen.cljc:239" (eval (quote (clojure.test/is (= :rct-clr.gen/foo (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::foo"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:245
+  (testing "gen.cljc:245" (eval (quote (clojure.test/is (= :clojure.string/join (rct-clr.rct-generated-test/bind-repl-vars! (read-expectation {:expectation-type (quote =>), :expectation-string "::string/join"} (quote rct-clr.gen))))))))
+  ;; gen.cljc:251
+  (testing "gen.cljc:251" (eval (quote (clojure.test/is (= 3 (rct-clr.rct-generated-test/bind-repl-vars! (count (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2 ...]"} (quote rct-clr.gen)))))))))
+  ;; gen.cljc:257
+  (testing "gen.cljc:257" (eval (quote (try (read-expectation {:expectation-type (quote =>), :expectation-string "[1 2"} (quote rct-clr.gen)) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert {} (rct-clr.rct-generated-test/error->map e))))))))
 (defn- rct-clr-gen-rct-block-4 []
-  ;; gen.cljc:297
-  (testing "gen.cljc:297" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:304
-  (testing "gen.cljc:304" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:312
-  (testing "gen.cljc:312" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:320
-  (testing "gen.cljc:320" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:328
-  (testing "gen.cljc:328" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:336
-  (testing "gen.cljc:336" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:350
-  (testing "gen.cljc:350" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
-  ;; gen.cljc:358
-  (testing "gen.cljc:358" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
+  ;; gen.cljc:292
+  (testing "gen.cljc:292" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (test-output-ns/bind-repl-vars! (def x 1))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type nil, :test-sexpr (quote (def x 1))} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:299
+  (testing "gen.cljc:299" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= 3 (test-output-ns/bind-repl-vars! (+ 1 2))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (+ 1 2)), :expectation-string "3"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:307
+  (testing "gen.cljc:307" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= (test-output-ns/eval-expectation (quote (:h :c :s :d nil))) (test-output-ns/bind-repl-vars! (order))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (order)), :expectation-string "(:h :c :s :d nil)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:315
+  (testing "gen.cljc:315" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert {:status 200} (test-output-ns/bind-repl-vars! (get-status)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (get-status)), :expectation-string "{:status 200}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:323
+  (testing "gen.cljc:323" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (matcho.core/assert [0 1] (test-output-ns/bind-repl-vars! (range 5)))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>>), :test-sexpr (quote (range 5)), :expectation-string "[0 1 ...]"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:331
+  (testing "gen.cljc:331" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (try (boom!) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:class Exception} (test-output-ns/error->map e))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote throws=>>), :test-sexpr (quote (boom!)), :expectation-string "{:error/class Exception}"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:345
+  (testing "gen.cljc:345" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :clr (test-output-ns/bind-repl-vars! (get-platform))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-platform)), :expectation-string "#?(:clj :jvm :cljr :clr)"} (quote rct-clr.gen) (quote test-output-ns))))))))
+  ;; gen.cljc:353
+  (testing "gen.cljc:353" (eval (quote (clojure.test/is (= (rct-clr.rct-generated-test/eval-expectation (quote (quote (clojure.test/is (= :rct-clr.gen/foo (test-output-ns/bind-repl-vars! (get-type))))))) (rct-clr.rct-generated-test/bind-repl-vars! (datum->form {:expectation-type (quote =>), :test-sexpr (quote (get-type)), :expectation-string "::foo"} (quote rct-clr.gen) (quote test-output-ns)))))))))
 (defn- rct-clr-gen-rct-block-5 []
-  ;; gen.cljc:373
-  (testing "gen.cljc:373" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
-  ;; gen.cljc:376
-  (testing "gen.cljc:376" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
+  ;; gen.cljc:368
+  (testing "gen.cljc:368" (eval (quote (clojure.test/is (= "my-cool-namespace" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote my.cool.namespace))))))))
+  ;; gen.cljc:370
+  (testing "gen.cljc:370" (eval (quote (clojure.test/is (= "single" (rct-clr.rct-generated-test/bind-repl-vars! (ns-sym->test-base (quote single)))))))))
 (defn- rct-clr-gen-rct-block-6 []
-  ;; gen.cljc:498
-  (testing "gen.cljc:498" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
-  ;; gen.cljc:502
-  (testing "gen.cljc:502" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
-  ;; gen.cljc:506
-  (testing "gen.cljc:506" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
-  ;; gen.cljc:510
-  (testing "gen.cljc:510" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
-  ;; gen.cljc:514
-  (testing "gen.cljc:514" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
-  ;; gen.cljc:518
-  (testing "gen.cljc:518" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
-  ;; gen.cljc:521
-  (testing "gen.cljc:521" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
+  ;; gen.cljc:491
+  (testing "gen.cljc:491" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:495
+  (testing "gen.cljc:495" (eval (quote (clojure.test/is (= {:ok {:src-dirs ["src1" "src2"], :output "out.cljc", :namespace "my.ns"}} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-s" "src1" "-s" "src2" "-o" "out.cljc" "-n" "my.ns"])))))))
+  ;; gen.cljc:499
+  (testing "gen.cljc:499" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-n" "my.ns"])))))))
+  ;; gen.cljc:503
+  (testing "gen.cljc:503" (eval (quote (clojure.test/is (= {:errors ["Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts ["-o" "out.cljc"])))))))
+  ;; gen.cljc:507
+  (testing "gen.cljc:507" (eval (quote (clojure.test/is (= {:errors ["Must provide --output / -o" "Must provide --namespace / -n"]} (rct-clr.rct-generated-test/bind-repl-vars! (validate-opts [])))))))
+  ;; gen.cljc:511
+  (testing "gen.cljc:511" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["--bogus"]) :errors)))))))
+  ;; gen.cljc:513
+  (testing "gen.cljc:513" (eval (quote (clojure.test/is (= true (rct-clr.rct-generated-test/bind-repl-vars! (contains? (validate-opts ["-h"]) :help))))))))
 (deftest rct-clr-gen-rct
   (binding [*ns* (the-ns 'rct-clr.gen)
             *1 nil, *2 nil, *3 nil, *e nil]

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer [deftest testing]]
             [matcho.core]
             [rct-clr.sample]
+            [rct-clr.sample-clj]
             [rct-clr.sample-clr]))
 
 (defn error->map [e]
@@ -148,6 +149,17 @@
     (rct-clr-sample-rct-block-15)
     (rct-clr-sample-rct-block-16)
     (rct-clr-sample-rct-block-17)))
+
+;; rct-clr.sample-clj
+(defn- rct-clr-sample-clj-rct-block-0 []
+  ;; sample_clj.clj:10
+  (testing "sample_clj.clj:10" (eval (quote (clojure.test/is (= 6 (rct-clr.sample-generated-test/bind-repl-vars! (total [1 2 3])))))))
+  ;; sample_clj.clj:13
+  (testing "sample_clj.clj:13" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (total []))))))))
+(deftest rct-clr-sample-clj-rct
+  (binding [*ns* (the-ns 'rct-clr.sample-clj)
+            *1 nil, *2 nil, *3 nil, *e nil]
+    (rct-clr-sample-clj-rct-block-0)))
 
 ;; rct-clr.sample-clr
 (defn- rct-clr-sample-clr-rct-block-0 []

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -155,9 +155,7 @@
 ;; rct-clr.sample-clj
 (defn- rct-clr-sample-clj-rct-block-0 []
   ;; sample_clj.clj:10
-  (testing "sample_clj.clj:10" (eval (quote (clojure.test/is (= 6 (rct-clr.sample-generated-test/bind-repl-vars! (total [1 2 3])))))))
-  ;; sample_clj.clj:12
-  (testing "sample_clj.clj:12" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (total []))))))))
+  (testing "sample_clj.clj:10" (eval (quote (clojure.test/is (= 6 (rct-clr.sample-generated-test/bind-repl-vars! (total [1 2 3]))))))))
 (deftest rct-clr-sample-clj-rct
   (binding [*ns* (the-ns 'rct-clr.sample-clj)
             *1 nil, *2 nil, *3 nil, *e nil]

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -27,109 +27,109 @@
 (defn- rct-clr-sample-rct-block-0 []
   ;; sample.cljc:17
   (testing "sample.cljc:17" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (add 1 2)))))))
-  ;; sample.cljc:20
-  (testing "sample.cljc:20" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (add -1 1)))))))
-  ;; sample.cljc:24
+  ;; sample.cljc:19
+  (testing "sample.cljc:19" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (add -1 1)))))))
+  ;; sample.cljc:22
   (eval (quote (rct-clr.sample-generated-test/bind-repl-vars! (def base-val 10))))
-  ;; sample.cljc:27
-  (testing "sample.cljc:27" (eval (quote (clojure.test/is (= 15 (rct-clr.sample-generated-test/bind-repl-vars! (add base-val 5)))))))
-  ;; sample.cljc:31
+  ;; sample.cljc:25
+  (testing "sample.cljc:25" (eval (quote (clojure.test/is (= 15 (rct-clr.sample-generated-test/bind-repl-vars! (add base-val 5)))))))
+  ;; sample.cljc:28
   (eval (quote (rct-clr.sample-generated-test/bind-repl-vars! (def doubled (* base-val 2)))))
-  ;; sample.cljc:33
-  (testing "sample.cljc:33" (eval (quote (clojure.test/is (= 21 (rct-clr.sample-generated-test/bind-repl-vars! (add doubled 1))))))))
+  ;; sample.cljc:30
+  (testing "sample.cljc:30" (eval (quote (clojure.test/is (= 21 (rct-clr.sample-generated-test/bind-repl-vars! (add doubled 1))))))))
 (defn- rct-clr-sample-rct-block-1 []
-  ;; sample.cljc:48
-  (testing "sample.cljc:48" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (:h :c :s :d))) (rct-clr.sample-generated-test/bind-repl-vars! (suits)))))))
-  ;; sample.cljc:52
-  (testing "sample.cljc:52" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (1 2 3))) (rct-clr.sample-generated-test/bind-repl-vars! (map inc (range 3))))))))
-  ;; sample.cljc:56
-  (testing "sample.cljc:56" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote foo)) (rct-clr.sample-generated-test/bind-repl-vars! (a-symbol)))))))
-  ;; sample.cljc:60
-  (testing "sample.cljc:60" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (+ 2 2))) (rct-clr.sample-generated-test/bind-repl-vars! (count (suits)))))))))
+  ;; sample.cljc:44
+  (testing "sample.cljc:44" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (:h :c :s :d))) (rct-clr.sample-generated-test/bind-repl-vars! (suits)))))))
+  ;; sample.cljc:47
+  (testing "sample.cljc:47" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (1 2 3))) (rct-clr.sample-generated-test/bind-repl-vars! (map inc (range 3))))))))
+  ;; sample.cljc:50
+  (testing "sample.cljc:50" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote foo)) (rct-clr.sample-generated-test/bind-repl-vars! (a-symbol)))))))
+  ;; sample.cljc:53
+  (testing "sample.cljc:53" (eval (quote (clojure.test/is (= (rct-clr.sample-generated-test/eval-expectation (quote (+ 2 2))) (rct-clr.sample-generated-test/bind-repl-vars! (count (suits)))))))))
 (defn- rct-clr-sample-rct-block-2 []
-  ;; sample.cljc:71
-  (testing "sample.cljc:71" (eval (quote (clojure.test/is (= [1 2 3] (rct-clr.sample-generated-test/bind-repl-vars! (stack-push [1 2] 3)))))))
-  ;; sample.cljc:75
-  (testing "sample.cljc:75" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (count *1)))))))
-  ;; sample.cljc:79
-  (testing "sample.cljc:79" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (peek *2))))))))
+  ;; sample.cljc:63
+  (testing "sample.cljc:63" (eval (quote (clojure.test/is (= [1 2 3] (rct-clr.sample-generated-test/bind-repl-vars! (stack-push [1 2] 3)))))))
+  ;; sample.cljc:66
+  (testing "sample.cljc:66" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (count *1)))))))
+  ;; sample.cljc:69
+  (testing "sample.cljc:69" (eval (quote (clojure.test/is (= 3 (rct-clr.sample-generated-test/bind-repl-vars! (peek *2))))))))
 (defn- rct-clr-sample-rct-block-3 []
-  ;; sample.cljc:90
-  (testing "sample.cljc:90" (eval (quote (clojure.test/is (= "Hello, World!" (rct-clr.sample-generated-test/bind-repl-vars! (greet "World")))))))
-  ;; sample.cljc:93
-  (testing "sample.cljc:93" (eval (quote (clojure.test/is (= "HELLO, TEST!" (rct-clr.sample-generated-test/bind-repl-vars! (str/upper-case (greet "test"))))))))
-  ;; sample.cljc:96
-  (testing "sample.cljc:96" (eval (quote (clojure.test/is (= "a, b, c" (rct-clr.sample-generated-test/bind-repl-vars! (str/join ", " ["a" "b" "c"])))))))
-  ;; sample.cljc:99
-  (testing "sample.cljc:99" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "")))))))
-  ;; sample.cljc:102
-  (testing "sample.cljc:102" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "x"))))))))
+  ;; sample.cljc:79
+  (testing "sample.cljc:79" (eval (quote (clojure.test/is (= "Hello, World!" (rct-clr.sample-generated-test/bind-repl-vars! (greet "World")))))))
+  ;; sample.cljc:81
+  (testing "sample.cljc:81" (eval (quote (clojure.test/is (= "HELLO, TEST!" (rct-clr.sample-generated-test/bind-repl-vars! (str/upper-case (greet "test"))))))))
+  ;; sample.cljc:83
+  (testing "sample.cljc:83" (eval (quote (clojure.test/is (= "a, b, c" (rct-clr.sample-generated-test/bind-repl-vars! (str/join ", " ["a" "b" "c"])))))))
+  ;; sample.cljc:85
+  (testing "sample.cljc:85" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "")))))))
+  ;; sample.cljc:87
+  (testing "sample.cljc:87" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (str/blank? "x"))))))))
 (defn- rct-clr-sample-rct-block-4 []
-  ;; sample.cljc:114
-  (testing "sample.cljc:114" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! (platform))))))))
+  ;; sample.cljc:98
+  (testing "sample.cljc:98" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! (platform))))))))
 (defn- rct-clr-sample-rct-block-5 []
-  ;; sample.cljc:125
-  (testing "sample.cljc:125" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (rct-clr.sample-generated-test/bind-repl-vars! (my-type))))))))
+  ;; sample.cljc:108
+  (testing "sample.cljc:108" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (rct-clr.sample-generated-test/bind-repl-vars! (my-type))))))))
 (defn- rct-clr-sample-rct-block-6 []
-  ;; sample.cljc:138
-  (testing "sample.cljc:138" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (rct-clr.sample-generated-test/bind-repl-vars! (alias-kws)))))))
-  ;; sample.cljc:144
-  (testing "sample.cljc:144" (eval (quote (clojure.test/is (= "clojure.string" (rct-clr.sample-generated-test/bind-repl-vars! (namespace :clojure.string/join))))))))
+  ;; sample.cljc:120
+  (testing "sample.cljc:120" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (rct-clr.sample-generated-test/bind-repl-vars! (alias-kws)))))))
+  ;; sample.cljc:127
+  (testing "sample.cljc:127" (eval (quote (clojure.test/is (= "clojure.string" (rct-clr.sample-generated-test/bind-repl-vars! (namespace :clojure.string/join))))))))
 (defn- rct-clr-sample-rct-block-7 []
-  ;; sample.cljc:159
-  (testing "sample.cljc:159" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (rct-clr.sample-generated-test/bind-repl-vars! (user-profile 1 "Alice")))))))
-  ;; sample.cljc:166
-  (testing "sample.cljc:166" (eval (quote (clojure.test/is (= "dark" (rct-clr.sample-generated-test/bind-repl-vars! (get-in (user-profile 1 "Alice") [:settings :theme]))))))))
+  ;; sample.cljc:141
+  (testing "sample.cljc:141" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (rct-clr.sample-generated-test/bind-repl-vars! (user-profile 1 "Alice")))))))
+  ;; sample.cljc:149
+  (testing "sample.cljc:149" (eval (quote (clojure.test/is (= "dark" (rct-clr.sample-generated-test/bind-repl-vars! (get-in (user-profile 1 "Alice") [:settings :theme]))))))))
 (defn- rct-clr-sample-rct-block-8 []
-  ;; sample.cljc:182
-  (testing "sample.cljc:182" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:users []}))))))
-  ;; sample.cljc:186
-  (testing "sample.cljc:186" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:count 5})))))))
+  ;; sample.cljc:164
+  (testing "sample.cljc:164" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:users []}))))))
+  ;; sample.cljc:167
+  (testing "sample.cljc:167" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:count 5})))))))
 (defn- rct-clr-sample-rct-block-9 []
-  ;; sample.cljc:201
-  (testing "sample.cljc:201" (eval (quote (matcho.core/assert [{:name "a"}] (rct-clr.sample-generated-test/bind-repl-vars! (scored-items))))))
-  ;; sample.cljc:205
-  (testing "sample.cljc:205" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (rct-clr.sample-generated-test/bind-repl-vars! (mapv :name (scored-items))))))))
+  ;; sample.cljc:183
+  (testing "sample.cljc:183" (eval (quote (matcho.core/assert [{:name "a"}] (rct-clr.sample-generated-test/bind-repl-vars! (scored-items))))))
+  ;; sample.cljc:186
+  (testing "sample.cljc:186" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (rct-clr.sample-generated-test/bind-repl-vars! (mapv :name (scored-items))))))))
 (defn- rct-clr-sample-rct-block-10 []
-  ;; sample.cljc:216
-  (testing "sample.cljc:216" (eval (quote (matcho.core/assert [0 1 1 2] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 7))))))
-  ;; sample.cljc:219
-  (testing "sample.cljc:219" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 3)))))))
+  ;; sample.cljc:196
+  (testing "sample.cljc:196" (eval (quote (matcho.core/assert [0 1 1 2] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 7))))))
+  ;; sample.cljc:198
+  (testing "sample.cljc:198" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 3)))))))
 (defn- rct-clr-sample-rct-block-11 []
-  ;; sample.cljc:230
-  (testing "sample.cljc:230" (eval (quote (clojure.test/is (= #{:c :b} (rct-clr.sample-generated-test/bind-repl-vars! (common-tags #{:c :b :a} #{:c :b :d})))))))
-  ;; sample.cljc:233
-  (testing "sample.cljc:233" (eval (quote (clojure.test/is (= #{:b :a} (rct-clr.sample-generated-test/bind-repl-vars! (set/union #{:a} #{:b}))))))))
+  ;; sample.cljc:208
+  (testing "sample.cljc:208" (eval (quote (clojure.test/is (= #{:c :b} (rct-clr.sample-generated-test/bind-repl-vars! (common-tags #{:c :b :a} #{:c :b :d})))))))
+  ;; sample.cljc:210
+  (testing "sample.cljc:210" (eval (quote (clojure.test/is (= #{:b :a} (rct-clr.sample-generated-test/bind-repl-vars! (set/union #{:a} #{:b}))))))))
 (defn- rct-clr-sample-rct-block-12 []
-  ;; sample.cljc:248
-  (testing "sample.cljc:248" (eval (quote (clojure.test/is (= "alice bob" (rct-clr.sample-generated-test/bind-repl-vars! (normalize-name "  Alice BOB  ")))))))
-  ;; sample.cljc:251
-  (testing "sample.cljc:251" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (rct-clr.sample-generated-test/bind-repl-vars! (make-user "  Alice BOB  "))))))))
+  ;; sample.cljc:224
+  (testing "sample.cljc:224" (eval (quote (clojure.test/is (= "alice bob" (rct-clr.sample-generated-test/bind-repl-vars! (normalize-name "  Alice BOB  ")))))))
+  ;; sample.cljc:226
+  (testing "sample.cljc:226" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (rct-clr.sample-generated-test/bind-repl-vars! (make-user "  Alice BOB  "))))))))
 (defn- rct-clr-sample-rct-block-13 []
-  ;; sample.cljc:263
-  (testing "sample.cljc:263" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:237
+  (testing "sample.cljc:237" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-14 []
-  ;; sample.cljc:277
-  (testing "sample.cljc:277" (eval (quote (clojure.test/is (= {:host "localhost"} (rct-clr.sample-generated-test/bind-repl-vars! (parse-config {:host "localhost"})))))))
-  ;; sample.cljc:281
-  (testing "sample.cljc:281" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
-  ;; sample.cljc:285
-  (testing "sample.cljc:285" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:250
+  (testing "sample.cljc:250" (eval (quote (clojure.test/is (= {:host "localhost"} (rct-clr.sample-generated-test/bind-repl-vars! (parse-config {:host "localhost"})))))))
+  ;; sample.cljc:253
+  (testing "sample.cljc:253" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
+  ;; sample.cljc:257
+  (testing "sample.cljc:257" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-15 []
-  ;; sample.cljc:301
-  (testing "sample.cljc:301" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (rct-clr.sample-generated-test/bind-repl-vars! (stringify-keys {:b {:c 2}, :a 1}))))))))
+  ;; sample.cljc:272
+  (testing "sample.cljc:272" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (rct-clr.sample-generated-test/bind-repl-vars! (stringify-keys {:b {:c 2}, :a 1}))))))))
 (defn- rct-clr-sample-rct-block-16 []
-  ;; sample.cljc:312
-  (testing "sample.cljc:312" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (truthy? 1)))))))
-  ;; sample.cljc:315
-  (testing "sample.cljc:315" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? nil)))))))
-  ;; sample.cljc:318
-  (testing "sample.cljc:318" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? false)))))))
-  ;; sample.cljc:321
-  (testing "sample.cljc:321" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (nil? nil))))))))
+  ;; sample.cljc:282
+  (testing "sample.cljc:282" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (truthy? 1)))))))
+  ;; sample.cljc:284
+  (testing "sample.cljc:284" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? nil)))))))
+  ;; sample.cljc:286
+  (testing "sample.cljc:286" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? false)))))))
+  ;; sample.cljc:288
+  (testing "sample.cljc:288" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (nil? nil))))))))
 (defn- rct-clr-sample-rct-block-17 []
-  ;; sample.cljc:332
-  (testing "sample.cljc:332" (eval (quote (clojure.test/is (= {} (rct-clr.sample-generated-test/bind-repl-vars! (ex-data (make-error "boom")))))))))
+  ;; sample.cljc:298
+  (testing "sample.cljc:298" (eval (quote (clojure.test/is (= {} (rct-clr.sample-generated-test/bind-repl-vars! (ex-data (make-error "boom")))))))))
 (deftest rct-clr-sample-rct
   (binding [*ns* (the-ns 'rct-clr.sample)
             *1 nil, *2 nil, *3 nil, *e nil]
@@ -156,8 +156,8 @@
 (defn- rct-clr-sample-clj-rct-block-0 []
   ;; sample_clj.clj:10
   (testing "sample_clj.clj:10" (eval (quote (clojure.test/is (= 6 (rct-clr.sample-generated-test/bind-repl-vars! (total [1 2 3])))))))
-  ;; sample_clj.clj:13
-  (testing "sample_clj.clj:13" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (total []))))))))
+  ;; sample_clj.clj:12
+  (testing "sample_clj.clj:12" (eval (quote (clojure.test/is (= 0 (rct-clr.sample-generated-test/bind-repl-vars! (total []))))))))
 (deftest rct-clr-sample-clj-rct
   (binding [*ns* (the-ns 'rct-clr.sample-clj)
             *1 nil, *2 nil, *3 nil, *e nil]
@@ -167,12 +167,12 @@
 (defn- rct-clr-sample-clr-rct-block-0 []
   ;; sample_clr.cljc:13
   (testing "sample_clr.cljc:13" (eval (quote (clojure.test/is (= "boom" (rct-clr.sample-generated-test/bind-repl-vars! (.Message (make-error "boom"))))))))
-  ;; sample_clr.cljc:17
-  (testing "sample_clr.cljc:17" (eval (quote (clojure.test/is (= "boom" (rct-clr.sample-generated-test/bind-repl-vars! (.Message (make-error "boom"))))))))
-  ;; sample_clr.cljc:21
-  (testing "sample_clr.cljc:21" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! :clr))))))
-  ;; sample_clr.cljc:25
-  (testing "sample_clr.cljc:25" (eval (quote (clojure.test/is (= "error: boom" (rct-clr.sample-generated-test/bind-repl-vars! (str "error: " (.Message (make-error "boom"))))))))))
+  ;; sample_clr.cljc:16
+  (testing "sample_clr.cljc:16" (eval (quote (clojure.test/is (= "boom" (rct-clr.sample-generated-test/bind-repl-vars! (.Message (make-error "boom"))))))))
+  ;; sample_clr.cljc:19
+  (testing "sample_clr.cljc:19" (eval (quote (clojure.test/is (= :clr (rct-clr.sample-generated-test/bind-repl-vars! :clr))))))
+  ;; sample_clr.cljc:22
+  (testing "sample_clr.cljc:22" (eval (quote (clojure.test/is (= "error: boom" (rct-clr.sample-generated-test/bind-repl-vars! (str "error: " (.Message (make-error "boom"))))))))))
 (deftest rct-clr-sample-clr-rct
   (binding [*ns* (the-ns 'rct-clr.sample-clr)
             *1 nil, *2 nil, *3 nil, *e nil]

--- a/test/rct_clr/sample_generated_test.cljc
+++ b/test/rct_clr/sample_generated_test.cljc
@@ -72,62 +72,64 @@
   (testing "sample.cljc:125" (eval (quote (clojure.test/is (= :rct-clr.sample/sample (rct-clr.sample-generated-test/bind-repl-vars! (my-type))))))))
 (defn- rct-clr-sample-rct-block-6 []
   ;; sample.cljc:138
-  (testing "sample.cljc:138" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (rct-clr.sample-generated-test/bind-repl-vars! (alias-kws))))))))
+  (testing "sample.cljc:138" (eval (quote (clojure.test/is (= {:clojure.string/join :string-alias, :clojure.set/union :set-alias, :clojure.walk/walk :walk-alias} (rct-clr.sample-generated-test/bind-repl-vars! (alias-kws)))))))
+  ;; sample.cljc:144
+  (testing "sample.cljc:144" (eval (quote (clojure.test/is (= "clojure.string" (rct-clr.sample-generated-test/bind-repl-vars! (namespace :clojure.string/join))))))))
 (defn- rct-clr-sample-rct-block-7 []
-  ;; sample.cljc:155
-  (testing "sample.cljc:155" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (rct-clr.sample-generated-test/bind-repl-vars! (user-profile 1 "Alice")))))))
-  ;; sample.cljc:162
-  (testing "sample.cljc:162" (eval (quote (clojure.test/is (= "dark" (rct-clr.sample-generated-test/bind-repl-vars! (get-in (user-profile 1 "Alice") [:settings :theme]))))))))
+  ;; sample.cljc:159
+  (testing "sample.cljc:159" (eval (quote (clojure.test/is (= {:id 1, :name "Alice", :settings {:theme "dark", :lang "en", :notifications true}, :tags #{:active :verified}} (rct-clr.sample-generated-test/bind-repl-vars! (user-profile 1 "Alice")))))))
+  ;; sample.cljc:166
+  (testing "sample.cljc:166" (eval (quote (clojure.test/is (= "dark" (rct-clr.sample-generated-test/bind-repl-vars! (get-in (user-profile 1 "Alice") [:settings :theme]))))))))
 (defn- rct-clr-sample-rct-block-8 []
-  ;; sample.cljc:178
-  (testing "sample.cljc:178" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:users []}))))))
   ;; sample.cljc:182
-  (testing "sample.cljc:182" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:count 5})))))))
+  (testing "sample.cljc:182" (eval (quote (matcho.core/assert {:status 200, :body {:users []}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:users []}))))))
+  ;; sample.cljc:186
+  (testing "sample.cljc:186" (eval (quote (matcho.core/assert {:body {:count 5}, :timing {:start 0}} (rct-clr.sample-generated-test/bind-repl-vars! (api-response {:count 5})))))))
 (defn- rct-clr-sample-rct-block-9 []
-  ;; sample.cljc:197
-  (testing "sample.cljc:197" (eval (quote (matcho.core/assert [{:name "a"}] (rct-clr.sample-generated-test/bind-repl-vars! (scored-items))))))
   ;; sample.cljc:201
-  (testing "sample.cljc:201" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (rct-clr.sample-generated-test/bind-repl-vars! (mapv :name (scored-items))))))))
+  (testing "sample.cljc:201" (eval (quote (matcho.core/assert [{:name "a"}] (rct-clr.sample-generated-test/bind-repl-vars! (scored-items))))))
+  ;; sample.cljc:205
+  (testing "sample.cljc:205" (eval (quote (matcho.core/assert ^#:matcho{:strict true} ["a" "b" "c"] (rct-clr.sample-generated-test/bind-repl-vars! (mapv :name (scored-items))))))))
 (defn- rct-clr-sample-rct-block-10 []
-  ;; sample.cljc:212
-  (testing "sample.cljc:212" (eval (quote (matcho.core/assert [0 1 1 2] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 7))))))
-  ;; sample.cljc:215
-  (testing "sample.cljc:215" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 3)))))))
+  ;; sample.cljc:216
+  (testing "sample.cljc:216" (eval (quote (matcho.core/assert [0 1 1 2] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 7))))))
+  ;; sample.cljc:219
+  (testing "sample.cljc:219" (eval (quote (matcho.core/assert ^#:matcho{:strict true} [0 1 1] (rct-clr.sample-generated-test/bind-repl-vars! (fibonacci 3)))))))
 (defn- rct-clr-sample-rct-block-11 []
-  ;; sample.cljc:226
-  (testing "sample.cljc:226" (eval (quote (clojure.test/is (= #{:c :b} (rct-clr.sample-generated-test/bind-repl-vars! (common-tags #{:c :b :a} #{:c :b :d})))))))
-  ;; sample.cljc:229
-  (testing "sample.cljc:229" (eval (quote (clojure.test/is (= #{:b :a} (rct-clr.sample-generated-test/bind-repl-vars! (set/union #{:a} #{:b}))))))))
+  ;; sample.cljc:230
+  (testing "sample.cljc:230" (eval (quote (clojure.test/is (= #{:c :b} (rct-clr.sample-generated-test/bind-repl-vars! (common-tags #{:c :b :a} #{:c :b :d})))))))
+  ;; sample.cljc:233
+  (testing "sample.cljc:233" (eval (quote (clojure.test/is (= #{:b :a} (rct-clr.sample-generated-test/bind-repl-vars! (set/union #{:a} #{:b}))))))))
 (defn- rct-clr-sample-rct-block-12 []
-  ;; sample.cljc:244
-  (testing "sample.cljc:244" (eval (quote (clojure.test/is (= "alice bob" (rct-clr.sample-generated-test/bind-repl-vars! (normalize-name "  Alice BOB  ")))))))
-  ;; sample.cljc:247
-  (testing "sample.cljc:247" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (rct-clr.sample-generated-test/bind-repl-vars! (make-user "  Alice BOB  "))))))))
+  ;; sample.cljc:248
+  (testing "sample.cljc:248" (eval (quote (clojure.test/is (= "alice bob" (rct-clr.sample-generated-test/bind-repl-vars! (normalize-name "  Alice BOB  ")))))))
+  ;; sample.cljc:251
+  (testing "sample.cljc:251" (eval (quote (clojure.test/is (= {:name "alice bob", :slug "alice-bob"} (rct-clr.sample-generated-test/bind-repl-vars! (make-user "  Alice BOB  "))))))))
 (defn- rct-clr-sample-rct-block-13 []
-  ;; sample.cljc:259
-  (testing "sample.cljc:259" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
+  ;; sample.cljc:263
+  (testing "sample.cljc:263" (eval (quote (try (validate-positive! -1) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:value -1}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-14 []
-  ;; sample.cljc:273
-  (testing "sample.cljc:273" (eval (quote (clojure.test/is (= {:host "localhost"} (rct-clr.sample-generated-test/bind-repl-vars! (parse-config {:host "localhost"})))))))
   ;; sample.cljc:277
-  (testing "sample.cljc:277" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
+  (testing "sample.cljc:277" (eval (quote (clojure.test/is (= {:host "localhost"} (rct-clr.sample-generated-test/bind-repl-vars! (parse-config {:host "localhost"})))))))
   ;; sample.cljc:281
-  (testing "sample.cljc:281" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
+  (testing "sample.cljc:281" (eval (quote (try (parse-config "oops") (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:got System.String}} (rct-clr.sample-generated-test/error->map e)))))))
+  ;; sample.cljc:285
+  (testing "sample.cljc:285" (eval (quote (try (parse-config {:port 8080}) (clojure.test/is false "Expected exception") (catch System.Exception e (set! *e e) (matcho.core/assert #:error{:data {:missing :host}} (rct-clr.sample-generated-test/error->map e))))))))
 (defn- rct-clr-sample-rct-block-15 []
-  ;; sample.cljc:297
-  (testing "sample.cljc:297" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (rct-clr.sample-generated-test/bind-repl-vars! (stringify-keys {:b {:c 2}, :a 1}))))))))
+  ;; sample.cljc:301
+  (testing "sample.cljc:301" (eval (quote (clojure.test/is (= {"a" 1, "b" {"c" 2}} (rct-clr.sample-generated-test/bind-repl-vars! (stringify-keys {:b {:c 2}, :a 1}))))))))
 (defn- rct-clr-sample-rct-block-16 []
-  ;; sample.cljc:308
-  (testing "sample.cljc:308" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (truthy? 1)))))))
-  ;; sample.cljc:311
-  (testing "sample.cljc:311" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? nil)))))))
-  ;; sample.cljc:314
-  (testing "sample.cljc:314" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? false)))))))
-  ;; sample.cljc:317
-  (testing "sample.cljc:317" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (nil? nil))))))))
+  ;; sample.cljc:312
+  (testing "sample.cljc:312" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (truthy? 1)))))))
+  ;; sample.cljc:315
+  (testing "sample.cljc:315" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? nil)))))))
+  ;; sample.cljc:318
+  (testing "sample.cljc:318" (eval (quote (clojure.test/is (= false (rct-clr.sample-generated-test/bind-repl-vars! (truthy? false)))))))
+  ;; sample.cljc:321
+  (testing "sample.cljc:321" (eval (quote (clojure.test/is (= true (rct-clr.sample-generated-test/bind-repl-vars! (nil? nil))))))))
 (defn- rct-clr-sample-rct-block-17 []
-  ;; sample.cljc:328
-  (testing "sample.cljc:328" (eval (quote (clojure.test/is (= {} (rct-clr.sample-generated-test/bind-repl-vars! (ex-data (make-error "boom")))))))))
+  ;; sample.cljc:332
+  (testing "sample.cljc:332" (eval (quote (clojure.test/is (= {} (rct-clr.sample-generated-test/bind-repl-vars! (ex-data (make-error "boom")))))))))
 (deftest rct-clr-sample-rct
   (binding [*ns* (the-ns 'rct-clr.sample)
             *1 nil, *2 nil, *3 nil, *e nil]


### PR DESCRIPTION
Closes #17, Closes #18
---

- `find-cljc-files` becomes `find-source-files`: scans `.clj` and `.cljc`, and keeps the `.cljc` when a namespace is present as both
- `build-resolver` keys the rewrite-clj auto-resolve map by the alias symbol, so an `::alias/kw` in a test expression keeps its namespace
- `examples/` gains a `.clj` sample and an alias-in-test-expression case, so both fixes run on MAGIC and ClojureCLR
- RCT expectations across the repo follow the style rules: under 75 characters inline, longer ones as data under a bare `;=>`
- Test cases that repeat a branch another case already covers are dropped
- `CONTRIBUTING.md` follows the shared template, and `CHANGELOG.md`, the issue and PR templates and the README links are added